### PR TITLE
TRACK-86 - Resetting primary key sequence to highest value on deploy

### DIFF
--- a/deploy/roles/webserver/tasks/main.yml
+++ b/deploy/roles/webserver/tasks/main.yml
@@ -156,6 +156,11 @@
   sudo_user: mindleaps
   shell: DEVISE_SECRET_KEY={{ devise_secret_key }} RAILS_ENV=production ~/.rvm/bin/rvm `cat ~/tracker/.ruby-version` do rails db:migrate chdir=/home/mindleaps/tracker
 
+- name: Reset Postgres sequences of table primary key ids
+  sudo: true
+  sudo_user: mindleaps
+  shell: DEVISE_SECRET_KEY={{ devise_secret_key }} RAILS_ENV=production ~/.rvm/bin/rvm `cat ~/tracker/.ruby-version` do rake db:correct_sequence_ids chdir=/home/mindleaps/tracker
+
 - name: Precompile the assets
   sudo: true
   sudo_user: mindleaps

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+namespace :db do
+  desc 'Reset Postgres sequences of table primary keys to highest value'
+  task correct_sequence_ids: :environment do
+    ActiveRecord::Base.connection.tables.each do |table|
+      ActiveRecord::Base.connection.reset_pk_sequence! table
+    end
+  end
+end


### PR DESCRIPTION
We are getting PK conflicts after the data migration. A new record would be inserted with an already existing id causing the rollback.

This will reset pg sequences to start after the highest existing value in the table.

Tested on staging where it fixed the issue.

@j16r :bowtie: 