### PR TITLE
Changed service ansible service module to systemd and added a daemon_…

### DIFF
--- a/deploy/roles/webserver/handlers/main.yml
+++ b/deploy/roles/webserver/handlers/main.yml
@@ -6,10 +6,11 @@
     enabled: yes
 
 - name: Restart tracker
-  service:
+  systemd:
     name: tracker
     state: restarted
     enabled: yes
+    daemon_reload: yes
 
 - name: Run DB migrations
   sudo: true


### PR DESCRIPTION
…reload param to reload the unit

Ansible is moving from the service module into more specific modules. Here we are using systemd module to restart tracker and passing the daemon_reload param to reload the unit configuration in case it changed.

Without it, if the configuration has changed, systemd gives the following output on reload:

```sh
Warning: tracker.service changed on disk. Run 'systemctl daemon-reload' to reload units.
```

https://docs.ansible.com/ansible/systemd_module.html
@j16r 