### PR TITLE
TRACK-106 - Validating Lesson for duplicates

### DIFF
--- a/app/controllers/api/lessons_controller.rb
+++ b/app/controllers/api/lessons_controller.rb
@@ -18,20 +18,26 @@ module Api
     def create
       lesson = Lesson.new lesson_params
 
-      respond_with_existing_lesson unless lesson.save
+      save_lesson lesson
 
       respond_with lesson, meta: { timestamp: Time.zone.now } unless performed?
     end
 
     private
 
+    def lesson_params
+      params.permit :group_id, :date, :subject_id
+    end
+
+    def save_lesson(lesson)
+      respond_with_existing_lesson unless lesson.save
+    rescue ActiveRecord::RecordNotUnique
+      respond_with_existing_lesson
+    end
+
     def respond_with_existing_lesson
       lesson = Lesson.find_by lesson_params
       respond_with(lesson, status: :ok, meta: { timestamp: Time.zone.now }) if lesson
-    end
-
-    def lesson_params
-      params.permit :group_id, :date, :subject_id
     end
   end
 end

--- a/app/controllers/api/lessons_controller.rb
+++ b/app/controllers/api/lessons_controller.rb
@@ -16,20 +16,22 @@ module Api
     end
 
     def create
-      lesson = Lesson.new params.permit :group_id, :date, :subject_id
-      begin
-        lesson.save
-      rescue ActiveRecord::RecordNotUnique
-        return respond_with_existing_lesson
-      end
-      respond_with lesson, meta: { timestamp: Time.zone.now }
+      lesson = Lesson.new lesson_params
+
+      respond_with_existing_lesson unless lesson.save
+
+      respond_with lesson, meta: { timestamp: Time.zone.now } unless performed?
     end
 
     private
 
     def respond_with_existing_lesson
-      lesson = Lesson.find_by group_id: params[:group_id], subject_id: params[:subject_id], date: params[:date]
-      respond_with lesson, status: :ok, meta: { timestamp: Time.zone.now }
+      lesson = Lesson.find_by lesson_params
+      respond_with(lesson, status: :ok, meta: { timestamp: Time.zone.now }) if lesson
+    end
+
+    def lesson_params
+      params.permit :group_id, :date, :subject_id
     end
   end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -8,6 +8,11 @@ class Lesson < ApplicationRecord
   scope :by_group, ->(group_id) { where group_id: group_id }
   scope :by_subject, ->(subject_id) { where subject_id: subject_id }
 
+  validates :date, uniqueness: {
+    scope: [:group, :subject],
+    message: ->(object, _data) { I18n.translate :duplicate_lesson, group: object.group.group_name, subject: object.subject.subject_name }
+  }
+
   def mark_student_as_absent(student)
     return if student_absent?(student)
 

--- a/spec/controllers/api/lessons_controller_spec.rb
+++ b/spec/controllers/api/lessons_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Api::LessonsController, type: :controller do
       @group = create :group
     end
 
-    context 'creating a non-existing lesson' do
+    context 'creating a new lesson' do
       before :each do
         post :create, format: :json, params: { group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_formatted_s }
       end

--- a/spec/controllers/lesson_controller_spec.rb
+++ b/spec/controllers/lesson_controller_spec.rb
@@ -58,6 +58,22 @@ RSpec.describe LessonsController, type: :controller do
           expect(created_lesson.subject).to eq @subject
         end
       end
+      context 'Tries to create an existing lesson' do
+        before :each do
+          @group = create :group
+          @subject = create :subject
+
+          create :lesson, group: @group, subject: @subject, date: Time.zone.today
+
+          post :create, params: { lesson: {
+            group_id: @group.id,
+            subject_id: @subject.id,
+            date: Time.zone.today
+          } }
+        end
+
+        it { should render_template :index }
+      end
     end
   end
 end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Lesson, type: :model do
         expect(create(:lesson, group: @group, date: Time.zone.yesterday)).to be_valid
         expect(create(:lesson, group: @group, date: Time.zone.today)).to be_valid
       end
+
+      it 'is expected to be invalid' do
+        lesson = build :lesson, group: @group, date: Time.zone.today, subject: @subject
+        expect(lesson).to be_invalid
+        expect(lesson.errors.messages[:date])
+          .to include "Lesson already exists for group \"#{lesson.group.group_name}\" in \"#{lesson.subject.subject_name}\" on selected date."
+      end
     end
   end
 


### PR DESCRIPTION
This way we can display an error message in the web interface when a user tries to save duplicate, rather than just exploding the app with constraint validation