### PR TITLE
Proof of concept average for lesson

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -31,4 +31,9 @@ class Lesson < ApplicationRecord
   def student_absent?(student)
     absences.any? { |absence| absence.student_id == student.id }
   end
+
+  def average_mark
+    marks = group.students.map(&:average_mark)
+    (marks.sum.to_f / marks.size).round(2)
+  end
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -55,6 +55,11 @@ class Student < ApplicationRecord
     end
   end
 
+  def average_mark
+    marks = grades.map(&:grade_descriptor).map(&:mark).flatten
+    (marks.sum.to_f / marks.size).round(2)
+  end
+
   private
 
   def current_grades_for_lesson(lesson_id)

--- a/app/views/shared/_lessons_table.slim
+++ b/app/views/shared/_lessons_table.slim
@@ -7,6 +7,7 @@ table class='mdl-data-table mdl-js-data-table resource-table'
       th class='mdl-data-table__cell--non-numeric' Group Name
       == render partial: 'shared/ordered_column', locals: { order_key: :date, column_name: 'Date' }
       th class='mdl-data-table__cell--non-numeric' Subject
+      th class='mdl-data-table__cell--non-numeric' Average Mark
 
   - lessons.each_with_index do |lesson, i|
     tr class='resource-row'
@@ -18,3 +19,5 @@ table class='mdl-data-table mdl-js-data-table resource-table'
         = link_to lesson.date, lesson_path(lesson)
       td class='mdl-data-table__cell--non-numeric'
         = link_to lesson.subject.subject_name, lesson_path(lesson)
+      td class='mdl-data-table__cell--numeric'
+        = link_to lesson.average_mark, lesson_path(lesson)


### PR DESCRIPTION
Builds on from https://github.com/MindLeaps/tracker/pull/345

This is very inefficient, big performance hit. I suggest changing lessons and students tables to store and update average on the fly and then this will just surface this rather than calculating it on the go.