### PR TITLE
1460: Organization deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Implemented Organization, Chapter & Group deletion
+- Fixed #1770 - students missing in lesson view
+- Added policy scoping for Subjects and Assignments
+
 ## 0.31.1 - Ruby 3.3.0
 - Upgraded Ruby to 3.3.0
 - Fixed #1805 - made sure to display form validation errors in red

--- a/app/components/table_components/organization_row.rb
+++ b/app/components/table_components/organization_row.rb
@@ -1,7 +1,7 @@
 class TableComponents::OrganizationRow < TableComponents::BaseRow
   erb_template <<~ERB
-    <div class="<%= 'shaded-row' if shaded? %> table-row-wrapper organization-row">
-      <a href="<%= helpers.organization_path @item %>" class="<%= 'shaded-row' if shaded? %> table-row-wrapper">
+    <div class="<%= 'shaded-row' if shaded? %> <%= 'deleted-row' if @item.deleted_at? %> table-row-wrapper organization-row">
+      <a href="<%= helpers.organization_path @item %>" class="<%= 'shaded-row' if shaded? %> <%= 'deleted-row' if @item.deleted_at? %> table-row-wrapper">
         <div class="table-cell "><%= @pagy.from + @item_counter %></div>
         <div class="table-cell "></span><%= @item.organization_mlid %></div>
         <div class="text-right table-cell "><%= @item.organization_name %></div>

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,6 +1,6 @@
 class OrganizationsController < HtmlController
   include Pagy::Backend
-  has_scope :exclude_deleted, type: :boolean, default: true, only: :index
+  has_scope :exclude_deleted, type: :boolean, default: true
   has_scope :table_order, type: :hash, default: { key: :created_at, order: :desc }, only: :index
   has_scope :table_order_chapters, type: :hash, only: :show
   has_scope :table_order_members, type: :hash, only: :show
@@ -57,10 +57,24 @@ class OrganizationsController < HtmlController
   end
 
   def initialize_organization(id)
-    @pagy_chapters, @chapters = pagy apply_scopes(ChapterSummary.where(organization_id: id), { table_order_chapters: params['table_order_chapters'] || { key: :chapter_name, order: :asc } })
-    @pagy_users, @members = pagy apply_scopes(@organization.members, { table_order_members: params['table_order_members'] || { key: :email, order: :asc } })
+    @pagy_chapters, @chapters = pagy apply_scopes(ChapterSummary.where(organization_id: id), chapter_order_scope)
+    @pagy_users, @members = pagy apply_scopes(@organization.members, member_order_scope)
     @new_member = User.new
     @roles = Role::LOCAL_ROLES.keys
+  end
+
+  def chapter_order_scope
+    {
+      table_order_chapters: params['table_order_chapters'] || { key: :chapter_name, order: :asc },
+      exclude_deleted: params['exclude_deleted'] || true
+    }
+  end
+
+  def member_order_scope
+    {
+      table_order_members: params['table_order_members'] || { key: :email, order: :asc },
+      exclude_deleted: nil
+    }
   end
 
   def add_member

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -80,8 +80,7 @@ class OrganizationsController < HtmlController
   def destroy
     @organization = Organization.find params.require :id
     authorize @organization
-    @organization.delete_organization_and_dependents
-    return unless @organization.save
+    return unless @organization.delete_organization_and_dependents
 
     success(title: t(:organization_deleted), text: t(:organization_deleted_text, organization: @organization.organization_name),
             button_path: undelete_organization_path, button_method: :post, button_text: t(:undo))
@@ -91,8 +90,7 @@ class OrganizationsController < HtmlController
   def undelete
     @organization = Organization.find params.require :id
     authorize @organization
-    @organization.restore_organization_and_dependents
-    return unless @organization.save
+    return unless @organization.restore_organization_and_dependents
 
     success(title: t(:organization_restored), text: t(:organization_restored_text, organization: @organization.organization_name))
     redirect_to organization_path

--- a/app/models/organization_summary.rb
+++ b/app/models/organization_summary.rb
@@ -4,6 +4,7 @@
 #
 #  id                :integer          primary key
 #  chapter_count     :integer
+#  deleted_at        :datetime
 #  group_count       :integer
 #  organization_mlid :string(3)
 #  organization_name :string

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -11,6 +11,10 @@ class OrganizationPolicy < ApplicationPolicy
     user.global_administrator?
   end
 
+  def undelete?
+    destroy?
+  end
+
   def add_member?
     user.global_administrator? || user.is_admin_of?(record)
   end

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -15,6 +15,7 @@
         <%= render SearchFormComponent.new(search: { term: params[:search] }, query_parameters: request.query_parameters) %>
       </div>
       <div class="flex-1 px-4">
+        <%= render CommonComponents::CheckboxLink.new(label: t(:show_deleted), checked: !excluding_deleted?, href: show_deleted_url) %>
       </div>
     </div>
   <% end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -4,11 +4,16 @@
   {title: CommonComponents::TagLabel.new(label: @organization.organization_name, img_src: 'world.svg'), href: '' },
 ], buttons: [
   (CommonComponents::ButtonComponent.new(label: t(:edit_organization), href: edit_organization_path(@organization)) if policy(@organization).edit?),
+  (CommonComponents::FormButtonComponent.new(label: t(:restore_organization), path: undelete_organization_path(@organization), method: :post) if policy(@organization).destroy? && @organization.deleted_at),
+  (CommonComponents::DangerousFormButtonComponent.new(label: t(:delete_organization), path: organization_path(@organization), method: :delete) if policy(@organization).destroy? && !@organization.deleted_at)
 ].compact)  do |h|
   h.with_left do
   end
 end %>
 
+<% if @organization.deleted_at  %>
+  <%= render AlertComponent.new(title: t(:organization_deleted, name: @organization.organization_name), text: t(:organization_deleted_at, time: distance_of_time_in_words(@organization.deleted_at, Time.zone.now))) %>
+<% end %>
 <div class="overflow-auto">
   <div class="flex">
     <section class="flex-1 pr-2">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,13 @@ en:
   organization_updated: Organization updated
   organization_name_added: Organization "%{name}" added
   organization_name_updated: Organization "%{name}" updated
+  organization_deleted: Organization deleted
+  organization_deleted_text: Organization "%{organization}" deleted.
+  organization_deleted_at: Organization deleted %{time} ago
+  organization_restored: Organization restored
+  organization_restored_text: Organization "%{organization}" restored.
+  delete_organization: Delete Organization
+  restore_organization: Restore Deleted Organization
 
   users: Users
   user_information: User Information

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,8 +43,9 @@ Rails.application.routes.draw do
       delete :revoke_global_role, on: :collection
     end
   end
-  resources :organizations, only: %i[index new create show edit update] do
+  resources :organizations, only: %i[index new create show edit update destroy] do
     member { post :add_member }
+    member { post :undelete }
   end
   resources :chapters, only: %i[index new create show edit update]
   resources :groups, only: %i[index new create show edit update destroy] do

--- a/db/migrate/20240415131224_update_organization_summaries_to_version_3.rb
+++ b/db/migrate/20240415131224_update_organization_summaries_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateOrganizationSummariesToVersion3 < ActiveRecord::Migration[7.0]
+  def change
+    replace_view :organization_summaries, version: 3, revert_to_version: 2
+  end
+end

--- a/db/migrate/20240415131224_update_organization_summaries_to_version_3.rb
+++ b/db/migrate/20240415131224_update_organization_summaries_to_version_3.rb
@@ -1,5 +1,5 @@
 class UpdateOrganizationSummariesToVersion3 < ActiveRecord::Migration[7.0]
   def change
-    replace_view :organization_summaries, version: 3, revert_to_version: 2
+    update_view :organization_summaries, version: 3, revert_to_version: 2
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -654,7 +654,8 @@ SELECT
     NULL::integer AS group_count,
     NULL::integer AS student_count,
     NULL::timestamp without time zone AS updated_at,
-    NULL::timestamp without time zone AS created_at;
+    NULL::timestamp without time zone AS created_at,
+    NULL::timestamp without time zone AS deleted_at;
 
 
 --
@@ -1750,7 +1751,8 @@ CREATE OR REPLACE VIEW public.organization_summaries AS
             ELSE 0
         END))::integer AS student_count,
     o.updated_at,
-    o.created_at
+    o.created_at,
+    o.deleted_at
    FROM (public.organizations o
      LEFT JOIN public.chapter_summaries c ON ((c.organization_id = o.id)))
   GROUP BY o.id;
@@ -2243,7 +2245,11 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231221220850'),
 ('20231222195655'),
 ('20231230202619'),
+('20240411100638'),
+('20240411121439'),
+('20240411131050'),
 ('20240412093631'),
-('20240412093830');
+('20240412093830'),
+('20240415131224');
 
 

--- a/db/views/organization_summaries_v03.sql
+++ b/db/views/organization_summaries_v03.sql
@@ -1,0 +1,11 @@
+SELECT o.id as id,
+       o.organization_name,
+       o.mlid as organization_mlid,
+       SUM(CASE WHEN c.id IS NOT NULL AND c.deleted_at IS NULL THEN 1 ELSE 0 END)::INT as chapter_count,
+       SUM(CASE WHEN c.id IS NOT NULL AND c.deleted_at IS NULL THEN c.group_count ELSE 0 END)::INT as group_count,
+       SUM(CASE WHEN c.id IS NOT NULL AND c.deleted_at IS NULL THEN c.student_count ELSE 0 END)::INT as student_count,
+       o.updated_at,
+       o.created_at,
+       o.deleted_at
+FROM organizations o LEFT JOIN chapter_summaries c on c.organization_id = o.id
+GROUP BY o.id;

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -97,4 +97,20 @@ RSpec.describe Organization, type: :model do
       expect(org.members).to include(OrganizationMember.find(@members[2].id))
     end
   end
+
+  describe 'scopes' do
+    before :each do
+      @org1 = create :organization
+      @org2 = create :organization
+      @org3 = create :organization, deleted_at: Time.zone.now
+    end
+
+    describe 'exclude_deleted' do
+      it 'returns only non-deleted organizations' do
+        expect(Organization.exclude_deleted.length).to eq 2
+        expect(Organization.exclude_deleted).to include @org1, @org2
+        expect(Organization.exclude_deleted).not_to include @org3
+      end
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -100,16 +100,82 @@ RSpec.describe Organization, type: :model do
 
   describe 'scopes' do
     before :each do
-      @org1 = create :organization
-      @org2 = create :organization
-      @org3 = create :organization, deleted_at: Time.zone.now
+      @first_organization = create :organization
+      @second_organization = create :organization
+      @deleted_organization = create :organization, deleted_at: Time.zone.now
     end
 
     describe 'exclude_deleted' do
       it 'returns only non-deleted organizations' do
-        expect(Organization.exclude_deleted.length).to eq 2
-        expect(Organization.exclude_deleted).to include @org1, @org2
-        expect(Organization.exclude_deleted).not_to include @org3
+        expect(Organization.exclude_deleted.length).to eq Organization.where(deleted_at: nil).length
+        expect(Organization.exclude_deleted).to include @first_organization, @second_organization
+        expect(Organization.exclude_deleted).not_to include @deleted_organization
+      end
+    end
+  end
+
+  describe 'methods' do
+    describe 'delete_organization_and_dependents' do
+      before :each do
+        @organization_to_delete = create :organization
+
+        @chapters = create_list :chapter, 2, organization: @organization_to_delete
+        @groups = create_list :group, 2, chapter: @chapters.first
+        @students = create_list :student, 2, group: @groups.first
+        @lessons = create_list :lesson, 2, group: @groups.first
+        @grades = create_list :grade, 2, lesson: @lessons.first
+        @deleted_chapter = create :chapter, organization: @organization_to_delete, deleted_at: Time.zone.now
+
+        @organization_to_delete.delete_organization_and_dependents
+        @organization_to_delete.reload
+      end
+
+      it 'marks the organization as deleted' do
+        expect(@organization_to_delete.deleted_at).to be_within(1.second).of Time.zone.now
+      end
+
+      it 'marks the organization\'s dependents as deleted' do
+        @chapters.each { |chapter| expect(chapter.reload.deleted_at).to eq(@organization_to_delete.deleted_at) }
+        @groups.each { |group| expect(group.reload.deleted_at).to eq(@organization_to_delete.deleted_at) }
+        @students.each { |student| expect(student.reload.deleted_at).to eq(@organization_to_delete.deleted_at) }
+        @lessons.each { |lesson| expect(lesson.reload.deleted_at).to eq(@organization_to_delete.deleted_at) }
+        @grades.each { |grade| expect(grade.reload.deleted_at).to eq(@organization_to_delete.deleted_at) }
+      end
+
+      it 'does not mark previously deleted dependents of the organization as deleted' do
+        expect(@deleted_chapter.reload.deleted_at).to_not eq(@organization_to_delete.deleted_at)
+      end
+    end
+
+    describe 'restore_organization_and_dependents' do
+      before :each do
+        @organization_to_restore = create :organization, deleted_at: Time.zone.now
+
+        @chapters = create_list :chapter, 2, organization: @organization_to_restore, deleted_at: @organization_to_restore.deleted_at
+        @groups = create_list :group, 2, chapter: @chapters.first, deleted_at: @organization_to_restore.deleted_at
+        @students = create_list :student, 2, group: @groups.first, deleted_at: @organization_to_restore.deleted_at
+        @lessons = create_list :lesson, 2, group: @groups.first, deleted_at: @organization_to_restore.deleted_at
+        @grades = create_list :grade, 2, lesson: @lessons.first, deleted_at: @organization_to_restore.deleted_at
+        @deleted_chapter = create :chapter, organization: @organization_to_restore, deleted_at: Time.zone.now
+
+        @organization_to_restore.restore_organization_and_dependents
+        @organization_to_restore.reload
+      end
+
+      it 'removes the organization\'s deleted timestamp' do
+        expect(@organization_to_restore.deleted_at).to be_nil
+      end
+
+      it 'remove the organization\'s dependents deleted timestamps' do
+        @chapters.each { |chapter| expect(chapter.reload.deleted_at).to be_nil }
+        @groups.each { |group| expect(group.reload.deleted_at).to be_nil }
+        @students.each { |student| expect(student.reload.deleted_at).to be_nil }
+        @lessons.each { |lesson| expect(lesson.reload.deleted_at).to be_nil }
+        @grades.each { |grade| expect(grade.reload.deleted_at).to be_nil }
+      end
+
+      it 'does not remove the previously deleted dependents of the chapter\'s deleted timestamp' do
+        expect(@deleted_chapter.reload.deleted_at).to_not be_nil
       end
     end
   end

--- a/spec/models/organization_summary_spec.rb
+++ b/spec/models/organization_summary_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                :integer          primary key
 #  chapter_count     :integer
+#  deleted_at        :datetime
 #  group_count       :integer
 #  organization_mlid :string(3)
 #  organization_name :string


### PR DESCRIPTION
# Feature for #1460 

- Set deleted_at property for deleted/restored organization and the same for dependents (chapters, groups, students, lessons, grades)
- Add indexing for deleted organizations and buttons to the UI to enable delete and restore actions
- Tests for the same
