### PR TITLE
1772: Duplicate tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Added validation for existing tags in an organization
 - Blocked users from removing a graded skill from a subject
 - Removed absence from student lesson summaries and added lesson date
 - Restructured Lessons to go by their UUID

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,4 +19,10 @@ class Tag < ApplicationRecord
   belongs_to :organization
 
   validates :tag_name, presence: true
+  validates :tag_name, uniqueness: {
+    scope: :organization_id,
+    message: lambda do |tag, data|
+      "Tag \"#{data[:value]}\" already exists in #{Organization.find(tag.organization_id).organization_name} organization"
+    end
+  }
 end

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -107,7 +107,7 @@ end %>
                 </div>
                 <div class="bg-gray-100 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
                   <dt class="text-sm font-medium text-gray-500"><%= t(:tags) %></dt>
-                  <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"><% @student.tags.each do |tag|%><span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-80"><%= tag.tag_name %></span><% end %></dd>
+                  <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"><% @student.tags.each do |tag|%><span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-80 mx-1"><%= tag.tag_name %></span><% end %></dd>
                 </div>
                 <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
                   <dt class="text-sm font-medium text-gray-500"><%= t(:notes) %></dt>

--- a/spec/controllers/student_tags_controller_spec.rb
+++ b/spec/controllers/student_tags_controller_spec.rb
@@ -86,12 +86,27 @@ RSpec.describe StudentTagsController, type: :controller do
       end
 
       it { should redirect_to student_tags_path }
-
       it 'creates a new tag' do
         tag = Tag.last
         expect(tag.tag_name).to eq 'My Test Tag'
         expect(tag.organization_id).to eq @org.id
         expect(tag.shared).to eq true
+      end
+
+      context 'with existing tag' do
+        before :each do
+          @org = create :organization
+          @existing_tag = create :tag, organization: @org, tag_name: 'Existing Tag'
+
+          post :create, params: { tag: {
+            tag_name: 'Existing Tag',
+            organization_id: @org.id,
+            shared: false
+          } }
+        end
+
+        it { should render_template :new }
+        it { should set_flash[:failure_notice] }
       end
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -24,5 +24,12 @@ RSpec.describe Tag, type: :model do
 
   describe 'validations' do
     it { should validate_presence_of :tag_name }
+    it 'when the same tag is created for an organization' do
+      @org = create :organization
+      create :tag, tag_name: 'Existing Tag', organization: @org
+      new_tag = Tag.new tag_name: 'Existing Tag', organization_id: @org
+
+      expect(new_tag).to_not be_valid
+    end
   end
 end


### PR DESCRIPTION
# Feature for #1772 

- Added validation when creating a tag with an existing name in an organization
- Some styling so that student tags show up more separated when viewing a single student
- Added tests for the same