### PR TITLE
2035: Fix for student summaries in report

### DIFF
--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -54,7 +54,7 @@ function displayLessonGraph(containerId, lessonId, data) {
 function displayAveragesGraph(containerId, studentId, data) {
   let responsiveOptions = [
     ['print', {
-      width: 400,
+      width: 460,
       height: 300,
       stretch: true,
       axisX:{

--- a/app/components/table_components/student_row_report.rb
+++ b/app/components/table_components/student_row_report.rb
@@ -1,6 +1,6 @@
 class TableComponents::StudentRowReport < TableComponents::BaseRow
   erb_template <<~ERB
-    <div class="<%= 'shaded-row' if shaded? %> <%= 'deleted-row' if !@item[:first_lesson] && !@item[:middle_lesson] && !@item[:last_lesson] %> table-row-wrapper student-row">
+    <div class="<%= 'shaded-row' if shaded? %> table-row-wrapper student-row">
         <div class="text-right table-cell "><%= @item[:first_name] %></div>
         <div class="text-right table-cell "><%= @item[:last_name] %></div>
         <div class="text-right table-cell "><%= @item[:first_lesson] %></div>


### PR DESCRIPTION
# Fix for #2035 

- Removed additional styling for empty student summaries in report
- Increased group averages width for print