### PR TITLE
2093: Fix enrollment timelines not rendering when new students are present

### DIFF
--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -163,7 +163,7 @@ function displayPercentagesGraph(containerId, data) {
 }
 
 
-function displayTimelineGraph(containerId, data){
+function displayTimelineGraph(containerId, data, summaries){
  let inMultipleYears = data.some(d => new Date(d.active_since).getFullYear() !== new Date(Date.now()).getFullYear()
       || new Date(d.inactive_since).getFullYear()  !== new Date(Date.now()).getFullYear())
 
@@ -172,7 +172,7 @@ function displayTimelineGraph(containerId, data){
         id: d.student_id,
         name: d.student_name,
         start: new Date(d.active_since),
-        end: d.inactive_since ? new Date(d.inactive_since) : new Date(),
+        end: new Date(d.inactive_since),
         progress: 0,
         dependencies: d.dependent_on,
         custom_class: 'timeline-pill'
@@ -204,8 +204,8 @@ function displayTimelineGraph(containerId, data){
      bar_corner_radius: 3,
      arrow_curve: 10,
      popup: null,
-     gantt_start: data[0].first_lesson,
-     gantt_end: data[0].last_lesson
+     gantt_start: summaries.first().lesson_date,
+     gantt_end: summaries.last().lesson_date
   });
 }
 

--- a/app/controllers/group_reports_controller.rb
+++ b/app/controllers/group_reports_controller.rb
@@ -58,11 +58,16 @@ class GroupReportsController < HtmlController
       student_id: "#{enrollment.student_id} #{pos}",
       student_name: Student.find_by(id: enrollment.student_id).proper_name,
       active_since: enrollment.active_since,
-      inactive_since: enrollment.inactive_since? || @group_lesson_summaries.last&.[](:lesson_date),
-      dependent_on: ordered_enrollments[pos - 1]&.student_id == enrollment.student_id ? "#{enrollment.student_id} #{pos - 1}" : '',
-      first_lesson: @group_lesson_summaries.first&.[](:lesson_date),
-      last_lesson: @group_lesson_summaries.last&.[](:lesson_date)
+      inactive_since: enrollment_end(enrollment),
+      dependent_on: ordered_enrollments[pos - 1]&.student_id == enrollment.student_id ? "#{enrollment.student_id} #{pos - 1}" : ''
     }
+  end
+
+  def enrollment_end(enrollment)
+    return enrollment.inactive_since if enrollment.inactive_since.present?
+    return Time.zone.now if @group_lesson_summaries.last && (enrollment.active_since.to_date > @group_lesson_summaries.last&.[](:lesson_date))
+
+    @group_lesson_summaries.last&.[](:lesson_date)
   end
 
   def single_enrollment(multiple_enrollments)

--- a/app/views/group_reports/show.html.erb
+++ b/app/views/group_reports/show.html.erb
@@ -102,10 +102,11 @@
       displayPercentagesGraph && displayPercentagesGraph(`#subject-${r.subject_id}-group_attendance`, r.group_summaries)
     })
 
-    let enrollmentTimelines = <%= @enrollment_timelines.to_json.html_safe %>
+    let enrollmentTimelines = <%= @enrollment_timelines.to_json.html_safe %>;
+    let lessonSummaries = <%= @group_lesson_summaries.to_json.html_safe %>
 
     if(enrollmentTimelines.length > 0) {
-      displayTimelineGraph && displayTimelineGraph('#group_enrollments', enrollmentTimelines)
+      displayTimelineGraph && displayTimelineGraph('#group_enrollments', enrollmentTimelines, lessonSummaries)
     }
 
     document.addEventListener('DOMContentLoaded', handlePrint)


### PR DESCRIPTION
# Fix for #2093 

- Made inactive_since for timeline enrollments to be either group's last lesson or today if not set