### PR TITLE
2094: Fix Enrollment dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Upgraded to Rails 7.2
 - Upgraded Ruby to 3.3.6
 - Added inline student creating & editing in Group view
+- Added database procedure which updates enrollments according to earliest grades
 
 ## 0.34.0 - Group Reports
 - Added Count of Graded/absent/total students and total lesson average mark in lesson view

--- a/db/migrate/20241120234016_update_enrollments_according_to_grades.rb
+++ b/db/migrate/20241120234016_update_enrollments_according_to_grades.rb
@@ -6,8 +6,8 @@ class UpdateEnrollmentsAccordingToGrades < ActiveRecord::Migration[7.2]
       AS $$
       BEGIN
         -- Find enrollments to fix
-        with tofix_enrollments as 
-        ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id 
+        with tofix_enrollments as
+        ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id
         from grades as g
         join students s on s.id = g.student_id
         join lessons l on g.lesson_id = l.id

--- a/db/migrate/20241120234016_update_enrollments_according_to_grades.rb
+++ b/db/migrate/20241120234016_update_enrollments_according_to_grades.rb
@@ -22,7 +22,6 @@ class UpdateEnrollmentsAccordingToGrades < ActiveRecord::Migration[7.2]
         where en.id = tfe.enrollment_id;
       END;
       $$;
-      CALL update_enrollments_by_grades();
     SQL
   end
 

--- a/db/migrate/20241120234016_update_enrollments_according_to_grades.rb
+++ b/db/migrate/20241120234016_update_enrollments_according_to_grades.rb
@@ -1,0 +1,35 @@
+class UpdateEnrollmentsAccordingToGrades < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      CREATE OR REPLACE PROCEDURE update_enrollments_by_grades()
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        -- Find enrollments to fix
+        with tofix_enrollments as 
+        ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id 
+        from grades as g
+        join students s on s.id = g.student_id
+        join lessons l on g.lesson_id = l.id
+        join groups gr on gr.id = l.group_id
+        join enrollments en on en.student_id = s.id and en.group_id = gr.id and en.active_since > l.date
+        where l.date > now() - '3 years'::interval
+        group by s.id, s.group_id, en.id
+        )
+
+        -- Update found enrollments
+        update enrollments en set active_since = tfe.earliest_lesson::timestamp
+        from tofix_enrollments tfe
+        where en.id = tfe.enrollment_id;
+      END;
+      $$;
+      CALL update_enrollments_by_grades();
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP PROCEDURE IF EXISTS update_enrollments_by_grades;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -99,16 +99,15 @@ CREATE PROCEDURE public.update_enrollments_by_grades()
     LANGUAGE plpgsql
     AS $$
 BEGIN
-  -- Find enrollments to fix
-  with tofix_enrollments as 
-  ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id 
-  from grades as g
-  join students s on s.id = g.student_id
-  join lessons l on g.lesson_id = l.id
-  join groups gr on gr.id = l.group_id
-  join enrollments en on en.student_id = s.id and en.group_id = gr.id and en.active_since > l.date
-  where l.date > now() - '3 years'::interval
-  group by s.id, s.group_id, en.id
+  -- Find enrollments to fix (ignore grades that reference lessons from more than 3 years ago)
+  with tofix_enrollments as
+  ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id
+    from grades as gr
+    join students s on s.id = gr.student_id
+    join lessons l on gr.lesson_id = l.id
+    join enrollments en on en.student_id = s.id and en.group_id = s.group_id and en.active_since::date > l.date
+    where l.date > now() - '3 years'::interval
+    group by s.id, s.group_id, en.id
   )
 
   -- Update found enrollments

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -92,6 +92,34 @@ $$;
 
 
 --
+-- Name: update_enrollments_by_grades(); Type: PROCEDURE; Schema: public; Owner: -
+--
+
+CREATE PROCEDURE public.update_enrollments_by_grades()
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  -- Find enrollments to fix
+  with tofix_enrollments as 
+  ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id 
+  from grades as g
+  join students s on s.id = g.student_id
+  join lessons l on g.lesson_id = l.id
+  join groups gr on gr.id = l.group_id
+  join enrollments en on en.student_id = s.id and en.group_id = gr.id and en.active_since > l.date
+  where l.date > now() - '3 years'::interval
+  group by s.id, s.group_id, en.id
+  )
+
+  -- Update found enrollments
+  update enrollments en set active_since = tfe.earliest_lesson::timestamp
+  from tofix_enrollments tfe
+  where en.id = tfe.enrollment_id;
+END;
+$$;
+
+
+--
 -- Name: update_records_with_unique_mlids(text, integer); Type: PROCEDURE; Schema: public; Owner: -
 --
 
@@ -1968,6 +1996,7 @@ ALTER TABLE ONLY public.users_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241120234016'),
 ('20241012105115'),
 ('20241011120532'),
 ('20240917090713'),


### PR DESCRIPTION
# Fix for #2094

- Added migration which introduces a new stored procedure
- Procedure finds grades for students and the enrollments which have a later date than their first lesson and updates them to be the first lesson's date