### PR TITLE
2120: Student API to return group_id according to Enrollments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Upgraded Ruby to 3.3.6
 - Added inline student creating & editing in Group view
 - Added database procedure which updates enrollments according to earliest grades
+- Modified Student API to return group_id according to Enrollments
 
 ## 0.34.0 - Group Reports
 - Added Count of Graded/absent/total students and total lesson average mark in lesson view

--- a/app/serializers/student_serializer.rb
+++ b/app/serializers/student_serializer.rb
@@ -46,4 +46,8 @@ class StudentSerializer < ActiveModel::Serializer
 
   belongs_to :group
   belongs_to :organization
+
+  def group_id
+    Enrollment.where(student_id: object.id, inactive_since: nil).order(active_since: :desc).first.group_id
+  end
 end

--- a/spec/requests/student_requests_spec.rb
+++ b/spec/requests/student_requests_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe 'Student API', type: :request do
   describe 'GET /students/:id' do
     before :each do
       @group = create :group
+      @current_group = create :group
       @student = create :student, group: @group, deleted_at: Time.zone.now
+      create :enrollment, student: @student, group: @current_group, inactive_since: nil
     end
 
     it 'responds with a specific student' do
@@ -31,6 +33,13 @@ RSpec.describe 'Student API', type: :request do
       get_with_token student_path(@student), params: { include: 'group' }, as: :json
 
       expect(student['group']['group_name']).to eq @group.group_name
+    end
+
+    it "responds with the student's group id as the one where its enrolled" do
+      get_with_token student_path(@student), as: :json
+
+      expect(student['group_id']).to_not eq @group.id
+      expect(student['group_id']).to eq @current_group.id
     end
   end
 


### PR DESCRIPTION
# Feature for #2120 

- Modified group_id attribute in student serializer 
- Added test for the same