### PR TITLE
2172: Enrollments update for active/inactive columns

### DIFF
--- a/app/controllers/api/enrollments_controller.rb
+++ b/app/controllers/api/enrollments_controller.rb
@@ -5,8 +5,12 @@ module Api
     has_scope :by_student, as: :student_id
 
     def index
-      @enrollments = apply_scopes(@api_version == 2 ? policy_scope(Enrollment) : Enrollment).all
-      respond_with @enrollments, include: included_params, meta: { timestamp: Time.zone.now }
+      @enrollments = apply_scopes([2, 3].include?(@api_version) ? policy_scope(Enrollment) : Enrollment).all
+      if @api_version == 3
+        respond_with @enrollments, include: included_params, meta: { timestamp: Time.zone.now }, each_serializer: EnrollmentSerializerV2
+      else
+        respond_with @enrollments, include: included_params, meta: { timestamp: Time.zone.now }, each_serializer: EnrollmentSerializer
+      end
     end
 
     def show

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -3,8 +3,8 @@
 # Table name: enrollments
 #
 #  id             :uuid             not null, primary key
-#  active_since   :datetime         not null
-#  inactive_since :datetime
+#  active_since   :date             not null
+#  inactive_since :date
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  group_id       :bigint           not null

--- a/app/serializers/enrollment_serializer.rb
+++ b/app/serializers/enrollment_serializer.rb
@@ -25,4 +25,12 @@ class EnrollmentSerializer < ActiveModel::Serializer
 
   belongs_to :student
   belongs_to :group
+
+  def active_since
+    object.active_since.to_datetime.iso8601
+  end
+
+  def inactive_since
+    object.inactive_since.present? ? object.inactive_since.to_datetime.iso8601 : nil
+  end
 end

--- a/app/serializers/enrollment_serializer.rb
+++ b/app/serializers/enrollment_serializer.rb
@@ -3,8 +3,8 @@
 # Table name: enrollments
 #
 #  id             :uuid             not null, primary key
-#  active_since   :datetime         not null
-#  inactive_since :datetime
+#  active_since   :date             not null
+#  inactive_since :date
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  group_id       :bigint           not null

--- a/app/serializers/enrollment_serializer_v2.rb
+++ b/app/serializers/enrollment_serializer_v2.rb
@@ -1,0 +1,6 @@
+class EnrollmentSerializerV2 < ActiveModel::Serializer
+  attributes :id, :active_since, :inactive_since, :created_at, :updated_at, :group_id, :student_id
+
+  belongs_to :student
+  belongs_to :group
+end

--- a/db/migrate/20250129182516_update_enrollment_columns.rb
+++ b/db/migrate/20250129182516_update_enrollment_columns.rb
@@ -1,0 +1,58 @@
+class UpdateEnrollmentColumns < ActiveRecord::Migration[7.2]
+  def up
+    drop_relative_views
+    change_column :enrollments, :active_since, :date, null: false
+    change_column :enrollments, :inactive_since, :date
+    update_enrollments_by_grades_procedure
+
+    execute <<~SQL
+      CALL update_enrollments_by_grades();
+    SQL
+
+    create_relative_views
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'This migration cannot be reverted because it modified data.'
+  end
+
+  def drop_relative_views
+    drop_view :group_lesson_summaries
+    drop_view :lesson_table_rows
+    drop_view :student_lesson_details
+    drop_view :student_lesson_summaries
+  end
+
+  def create_relative_views
+    create_view :student_lesson_summaries, version: 8
+    create_view :student_lesson_details, version: 5
+    create_view :lesson_table_rows, version: 4
+    create_view :group_lesson_summaries, version: 5
+  end
+
+  def update_enrollments_by_grades_procedure
+    execute <<~SQL
+      CREATE OR REPLACE PROCEDURE update_enrollments_by_grades()
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        -- Find enrollments to fix (ignore grades that reference lessons from more than 3 years ago)
+        with tofix_enrollments as
+        ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id
+          from grades as gr
+          join students s on s.id = gr.student_id
+          join lessons l on gr.lesson_id = l.id
+          join enrollments en on en.student_id = s.id and en.group_id = s.group_id and en.active_since > l.date
+          where l.date > now() - '3 years'::interval
+          group by s.id, s.group_id, en.id
+        )
+
+        -- Update found enrollments
+        update enrollments en set active_since = tfe.earliest_lesson
+        from tofix_enrollments tfe
+        where en.id = tfe.enrollment_id;
+      END;
+      $$;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -99,20 +99,19 @@ CREATE PROCEDURE public.update_enrollments_by_grades()
     LANGUAGE plpgsql
     AS $$
 BEGIN
-  -- Find enrollments to fix
-  with tofix_enrollments as 
-  ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id 
-  from grades as g
-  join students s on s.id = g.student_id
-  join lessons l on g.lesson_id = l.id
-  join groups gr on gr.id = l.group_id
-  join enrollments en on en.student_id = s.id and en.group_id = gr.id and en.active_since > l.date
-  where l.date > now() - '3 years'::interval
-  group by s.id, s.group_id, en.id
+  -- Find enrollments to fix (ignore grades that reference lessons from more than 3 years ago)
+  with tofix_enrollments as
+  ( select s.id as student_id, s.group_id, min(l.date) as earliest_lesson, min(en.active_since) as enrollment_date, en.id as enrollment_id
+    from grades as gr
+    join students s on s.id = gr.student_id
+    join lessons l on gr.lesson_id = l.id
+    join enrollments en on en.student_id = s.id and en.group_id = s.group_id and en.active_since > l.date
+    where l.date > now() - '3 years'::interval
+    group by s.id, s.group_id, en.id
   )
 
   -- Update found enrollments
-  update enrollments en set active_since = tfe.earliest_lesson::timestamp
+  update enrollments en set active_since = tfe.earliest_lesson
   from tofix_enrollments tfe
   where en.id = tfe.enrollment_id;
 END;
@@ -336,6 +335,8 @@ CREATE TABLE public.enrollments (
     group_id bigint NOT NULL,
     active_since timestamp without time zone NOT NULL,
     inactive_since timestamp without time zone,
+    active_since date NOT NULL,
+    inactive_since date,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
@@ -1728,35 +1729,36 @@ CREATE OR REPLACE VIEW public.student_lesson_summaries AS
              JOIN public.groups g ON ((g.id = en.group_id)))
              JOIN public.lessons l ON ((l.group_id = g.id)))
              LEFT JOIN public.grades ON (((grades.student_id = s.id) AND (grades.lesson_id = l.id) AND (grades.deleted_at IS NULL))))
-          WHERE ((en.active_since < (l.date + 1)) AND ((en.inactive_since IS NULL) OR (en.inactive_since > (l.date - 1))))
+          WHERE ((en.active_since <= l.date) AND ((en.inactive_since IS NULL) OR (en.inactive_since >= l.date)))
           GROUP BY s.id, l.id) united
      JOIN public.subject_summaries su ON ((united.subject_id = su.id)));
 
 
 --
--- Name: group_lesson_summaries _RETURN; Type: RULE; Schema: public; Owner: -
+-- Name: student_lesson_details _RETURN; Type: RULE; Schema: public; Owner: -
 --
 
-CREATE OR REPLACE VIEW public.group_lesson_summaries AS
- SELECT slu.lesson_id,
-    slu.lesson_date,
-    gr.id AS group_id,
-    gr.chapter_id,
-    slu.subject_id,
-    concat(gr.group_name, ' - ', c.chapter_name) AS group_chapter_name,
-    (round(avg(slu.average_mark), 2))::double precision AS average_mark,
-    (sum(slu.grade_count))::bigint AS grade_count,
-    (round((((sum(
-        CASE
-            WHEN (slu.grade_count = 0) THEN 0
-            ELSE 1
-        END))::numeric / (count(slu.*))::numeric) * (100)::numeric), 2))::double precision AS attendance
-   FROM ((public.student_lesson_summaries slu
-     JOIN public.groups gr ON ((slu.group_id = gr.id)))
-     JOIN public.chapters c ON ((gr.chapter_id = c.id)))
-  WHERE (slu.deleted_at IS NULL)
-  GROUP BY slu.lesson_id, gr.id, c.id, slu.subject_id, slu.lesson_date
-  ORDER BY slu.lesson_date;
+CREATE OR REPLACE VIEW public.student_lesson_details AS
+ SELECT s.id AS student_id,
+    s.first_name,
+    s.last_name,
+    s.deleted_at AS student_deleted_at,
+    l.id AS lesson_id,
+    l.date,
+    l.deleted_at AS lesson_deleted_at,
+    l.subject_id,
+    round(avg(g.mark), 2) AS average_mark,
+    count(g.mark) AS grade_count,
+    COALESCE(jsonb_object_agg(g.skill_id, jsonb_build_object('mark', g.mark, 'grade_descriptor_id', g.grade_descriptor_id, 'skill_name', sk.skill_name)) FILTER (WHERE (sk.skill_name IS NOT NULL)), '{}'::jsonb) AS skill_marks
+   FROM (((((public.students s
+     JOIN public.groups gr ON ((gr.id = s.group_id)))
+     JOIN public.lessons l ON ((gr.id = l.group_id)))
+     JOIN public.enrollments en ON ((s.id = en.student_id)))
+     LEFT JOIN public.grades g ON (((g.student_id = s.id) AND (g.lesson_id = l.id) AND (g.deleted_at IS NULL))))
+     LEFT JOIN public.skills sk ON ((sk.id = g.skill_id)))
+  WHERE ((en.active_since <= l.date) AND ((en.inactive_since IS NULL) OR (en.inactive_since >= l.date)))
+  GROUP BY s.id, l.id
+  ORDER BY l.subject_id;
 
 
 --
@@ -1790,52 +1792,29 @@ CREATE OR REPLACE VIEW public.lesson_table_rows AS
 
 
 --
--- Name: student_averages _RETURN; Type: RULE; Schema: public; Owner: -
+-- Name: group_lesson_summaries _RETURN; Type: RULE; Schema: public; Owner: -
 --
 
-CREATE OR REPLACE VIEW public.student_averages AS
- SELECT s.id AS student_id,
-    s.first_name,
-    s.last_name,
-    s.deleted_at AS student_deleted_at,
-    su.id AS subject_id,
-    su.subject_name,
-    sk.skill_name,
-    round(avg(g.mark), 2) AS average_mark
-   FROM (((((public.students s
-     JOIN public.grades g ON (((g.student_id = s.id) AND (g.deleted_at IS NULL))))
-     JOIN public.skills sk ON ((sk.id = g.skill_id)))
-     JOIN public.assignments a ON ((a.skill_id = sk.id)))
-     JOIN public.subjects su ON ((su.id = a.subject_id)))
-     JOIN public.lessons l ON (((l.id = g.lesson_id) AND (l.subject_id = su.id))))
-  GROUP BY s.id, su.id, sk.skill_name;
-
-
---
--- Name: student_lesson_details _RETURN; Type: RULE; Schema: public; Owner: -
---
-
-CREATE OR REPLACE VIEW public.student_lesson_details AS
- SELECT s.id AS student_id,
-    s.first_name,
-    s.last_name,
-    s.deleted_at AS student_deleted_at,
-    l.id AS lesson_id,
-    l.date,
-    l.deleted_at AS lesson_deleted_at,
-    l.subject_id,
-    round(avg(g.mark), 2) AS average_mark,
-    count(g.mark) AS grade_count,
-    COALESCE(jsonb_object_agg(g.skill_id, jsonb_build_object('mark', g.mark, 'grade_descriptor_id', g.grade_descriptor_id, 'skill_name', sk.skill_name)) FILTER (WHERE (sk.skill_name IS NOT NULL)), '{}'::jsonb) AS skill_marks
-   FROM (((((public.students s
-     JOIN public.groups gr ON ((gr.id = s.group_id)))
-     JOIN public.lessons l ON ((gr.id = l.group_id)))
-     JOIN public.enrollments en ON ((s.id = en.student_id)))
-     LEFT JOIN public.grades g ON (((g.student_id = s.id) AND (g.lesson_id = l.id) AND (g.deleted_at IS NULL))))
-     LEFT JOIN public.skills sk ON ((sk.id = g.skill_id)))
-  WHERE ((en.active_since < (l.date + 1)) AND ((en.inactive_since IS NULL) OR (en.inactive_since > (l.date - 1))))
-  GROUP BY s.id, l.id
-  ORDER BY l.subject_id;
+CREATE OR REPLACE VIEW public.group_lesson_summaries AS
+ SELECT slu.lesson_id,
+    slu.lesson_date,
+    gr.id AS group_id,
+    gr.chapter_id,
+    slu.subject_id,
+    concat(gr.group_name, ' - ', c.chapter_name) AS group_chapter_name,
+    (round(avg(slu.average_mark), 2))::double precision AS average_mark,
+    (sum(slu.grade_count))::bigint AS grade_count,
+    (round((((sum(
+        CASE
+            WHEN (slu.grade_count = 0) THEN 0
+            ELSE 1
+        END))::numeric / (count(slu.*))::numeric) * (100)::numeric), 2))::double precision AS attendance
+   FROM ((public.student_lesson_summaries slu
+     JOIN public.groups gr ON ((slu.group_id = gr.id)))
+     JOIN public.chapters c ON ((gr.chapter_id = c.id)))
+  WHERE (slu.deleted_at IS NULL)
+  GROUP BY slu.lesson_id, gr.id, c.id, slu.subject_id, slu.lesson_date
+  ORDER BY slu.lesson_date;
 
 
 --
@@ -2036,6 +2015,7 @@ ALTER TABLE ONLY public.users_roles
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250129182516'),
 ('20250125235507'),
 ('20250124144809'),
 ('20241120234016'),

--- a/db/views/student_lesson_details_v05.sql
+++ b/db/views/student_lesson_details_v05.sql
@@ -1,0 +1,23 @@
+SELECT s.id                AS student_id,
+       s.first_name        AS first_name,
+       s.last_name         AS last_name,
+       s.deleted_at        AS student_deleted_at,
+       l.id                AS lesson_id,
+       l.date              AS date,
+       l.deleted_at        AS lesson_deleted_at,
+       l.subject_id        AS subject_id,
+       round(avg(mark), 2) AS average_mark,
+       count(mark)         AS grade_count,
+       coalesce(jsonb_object_agg(skill_id, jsonb_build_object(
+                   'mark', mark,
+                   'grade_descriptor_id', grade_descriptor_id,
+                   'skill_name', skill_name)) FILTER (WHERE skill_name IS NOT NULL), '{}'::jsonb) AS skill_marks
+FROM students s
+       JOIN groups gr on gr.id = s.group_id
+       JOIN lessons l on gr.id = l.group_id
+       JOIN enrollments en ON s.id = en.student_id
+       LEFT JOIN grades g on (g.student_id = s.id AND g.lesson_id = l.id AND g.deleted_at IS NULL)
+       LEFT JOIN skills sk on sk.id = g.skill_id
+WHERE en.active_since <= l.date AND (en.inactive_since IS NULL OR en.inactive_since >= l.date)
+GROUP BY s.id, l.id
+ORDER BY l.subject_id;

--- a/db/views/student_lesson_summaries_v08.sql
+++ b/db/views/student_lesson_summaries_v08.sql
@@ -1,0 +1,19 @@
+SELECT united.*, skill_count
+FROM ( SELECT s.id                AS student_id,
+              l.group_id          AS group_id,
+              s.first_name        AS first_name,
+              s.last_name         AS last_name,
+              s.deleted_at        AS deleted_at,
+              l.id                AS lesson_id,
+              l.date              AS lesson_date,
+              l.subject_id        AS subject_id,
+              round(AVG(mark), 2) AS average_mark,
+              COUNT(mark)         AS grade_count
+       FROM students s
+                JOIN enrollments en ON s.id = en.student_id
+                JOIN groups g ON g.id = en.group_id
+                JOIN lessons l ON l.group_id = g.id
+                LEFT JOIN grades ON (grades.student_id = s.id AND grades.lesson_id = l.id AND grades.deleted_at IS NULL)
+       WHERE en.active_since <= l.date AND (en.inactive_since IS NULL OR en.inactive_since >= l.date)
+       GROUP BY s.id, l.id
+     ) united JOIN subject_summaries su ON united.subject_id = su.id

--- a/spec/controllers/api/enrollments_controller_spec.rb
+++ b/spec/controllers/api/enrollments_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Api::EnrollmentsController, type: :controller do
   describe '#index' do
     before :each do
       create_list :enrollment, 3
+      @request.env['HTTP_ACCEPT'] = 'application/json, version=3'
       get :index, format: :json
     end
 

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -3,8 +3,8 @@
 # Table name: enrollments
 #
 #  id             :uuid             not null, primary key
-#  active_since   :datetime         not null
-#  inactive_since :datetime
+#  active_since   :date             not null
+#  inactive_since :date
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  group_id       :bigint           not null
@@ -24,6 +24,6 @@ FactoryBot.define do
   factory :enrollment do
     student { create :student }
     group { create :group }
-    active_since { Time.zone.now }
+    active_since { Time.zone.today }
   end
 end

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -3,8 +3,8 @@
 # Table name: enrollments
 #
 #  id             :uuid             not null, primary key
-#  active_since   :datetime         not null
-#  inactive_since :datetime
+#  active_since   :date             not null
+#  inactive_since :date
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  group_id       :bigint           not null
@@ -39,7 +39,7 @@ RSpec.describe Enrollment, type: :model do
     it 'the inactivity on student changing a group' do
       @student.update(group: @second_group)
 
-      expect(@enrollment.reload.inactive_since).to be_within(1.second).of(Time.zone.now)
+      expect(@enrollment.reload.inactive_since).to eq(Time.zone.today)
     end
 
     it 'a new enrollment on student changing a group' do
@@ -47,7 +47,7 @@ RSpec.describe Enrollment, type: :model do
 
       @new_enrollment = Enrollment.find_by(student: @student, group: @second_group)
 
-      expect(@new_enrollment.active_since).to be_within(1.second).of(Time.zone.now)
+      expect(@new_enrollment.active_since).to eq(Time.zone.today)
       expect(@new_enrollment.inactive_since).to be nil
     end
   end

--- a/spec/requests/student_requests_spec.rb
+++ b/spec/requests/student_requests_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Student API', type: :request do
       @group = create :group
       @current_group = create :group
       @student = create :student, group: @group, deleted_at: Time.zone.now
-      create :enrollment, student: @student, group: @current_group, inactive_since: nil
+      create :enrollment, student: @student, group: @current_group, active_since: 1.day.after, inactive_since: nil
     end
 
     it 'responds with a specific student' do

--- a/spec/schemas/enrollment.json
+++ b/spec/schemas/enrollment.json
@@ -6,8 +6,8 @@
   "required": ["id", "active_since", "inactive_since", "created_at", "updated_at", "group_id", "student_id"],
   "properties": {
     "id": { "$ref": "file:/uuid.json#" },
-    "active_since": {"type": ["string"], "format": "date-time"},
-    "inactive_since": {"type": ["string", "null"], "format": "date-time"},
+    "active_since": {"type": ["string"], "format": "date"},
+    "inactive_since": {"type": ["string", "null"], "format": "date"},
     "created_at": {"type": ["string"], "format": "date-time"},
     "updated_at": {"type": ["string"], "format": "date-time"},
     "group_id": {"type": "number"},


### PR DESCRIPTION
# Feature for #2172 

- Created migration which:
    - Changes Enrollment active/inactive columns to date types
    - Recreates any relevant views with updated versions
    - Updates and reruns stored procedure to fix enrollment values according to grades
- Modified tests