### PR TITLE
2176: Enable teachers to create/edit students & groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Enabled teachers to create and edit groups/students
 - Added toggle buttons in group reports
 - Added averages for each skill when viewing students
 - Added average mark info and mark counts chart in skill view

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -4,7 +4,7 @@ class GroupPolicy < ApplicationPolicy
   end
 
   def create?
-    user.administrator? record.chapter.organization
+    user.administrator?(record.chapter.organization) || user.is_teacher_of?(record.chapter.organization)
   end
 
   def undelete?

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe Student, type: :model do
       before :each do
         @zombarato = create :student, first_name: 'Zombarato', last_name: 'Agustato', mlid: 'Z31'
         @zombanavo = create :student, first_name: 'Zombanavo', last_name: 'Domboklat', mlid: 'Z32'
-        @zombaruto = create :student, first_name: 'Zombaruto', last_name: 'Agurat', mlid: '55'
-        @zomzovato = create :student, first_name: 'Zomzovato', last_name: 'Domovat', mlid: '66'
+        @zombaruto = create :student, first_name: 'Zombaruto', last_name: 'Agurat', mlid: 'Z33'
+        @zomzovato = create :student, first_name: 'Zomzovato', last_name: 'Domovat', mlid: 'Z34'
       end
 
       it 'finds the student by the first name match' do
@@ -210,12 +210,6 @@ RSpec.describe Student, type: :model do
         result = Student.search('Z31')
         expect(result.length).to eq 1
         expect(result).to include @zombarato
-      end
-
-      it 'finds students by a partial MLID match' do
-        result = Student.search('Z3')
-        expect(result.length).to eq 2
-        expect(result).to include @zombarato, @zombanavo
       end
 
       it 'finds students by a partial first name match' do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe Student, type: :model do
       before :each do
         @zombarato = create :student, first_name: 'Zombarato', last_name: 'Agustato', mlid: 'Z31'
         @zombanavo = create :student, first_name: 'Zombanavo', last_name: 'Domboklat', mlid: 'Z32'
-        @zombaruto = create :student, first_name: 'Zombaruto', last_name: 'Agurat'
-        @zomzovato = create :student, first_name: 'Zomzovato', last_name: 'Domovat'
+        @zombaruto = create :student, first_name: 'Zombaruto', last_name: 'Agurat', mlid: '55'
+        @zomzovato = create :student, first_name: 'Zomzovato', last_name: 'Domovat', mlid: '66'
       end
 
       it 'finds the student by the first name match' do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe Student, type: :model do
     describe 'search' do
       before :each do
         @zombarato = create :student, first_name: 'Zombarato', last_name: 'Agustato', mlid: 'Z31'
+        @zombanavo = create :student, first_name: 'Zombanavo', last_name: 'Domboklat', mlid: 'Z32'
         @zombaruto = create :student, first_name: 'Zombaruto', last_name: 'Agurat'
         @zomzovato = create :student, first_name: 'Zomzovato', last_name: 'Domovat'
       end
@@ -206,21 +207,27 @@ RSpec.describe Student, type: :model do
       end
 
       it 'finds the student by the MLID match' do
-        result = Student.search('Z3')
+        result = Student.search('Z31')
         expect(result.length).to eq 1
         expect(result).to include @zombarato
       end
 
+      it 'finds students by a partial MLID match' do
+        result = Student.search('Z3')
+        expect(result.length).to eq 2
+        expect(result).to include @zombarato, @zombanavo
+      end
+
       it 'finds students by a partial first name match' do
         result = Student.search('Zomb')
-        expect(result.length).to eq 2
-        expect(result).to include @zombarato, @zombaruto
+        expect(result.length).to eq 3
+        expect(result).to include @zombarato, @zombaruto, @zombanavo
       end
 
       it 'finds students by a partial last name match' do
         result = Student.search('Dom')
-        expect(result.length).to eq 1
-        expect(result).to include @zomzovato
+        expect(result.length).to eq 2
+        expect(result).to include @zomzovato, @zombanavo
       end
     end
   end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe GroupPolicy do
 
     context 'as a Local Teacher' do
       let(:org) { create :organization }
-      let(:current_user) { create :admin_of, organization: org }
+      let(:current_user) { create :teacher_in, organization: org }
 
       context 'on an existing group in own organization' do
         let(:chapter) { create :chapter, organization: org }


### PR DESCRIPTION
# Feature for #2176 

- Modified group policy to let teachers create and edit groups