### PR TITLE
2198: Form deprecation warning

### DIFF
--- a/app/components/form_wrapper_component.rb
+++ b/app/components/form_wrapper_component.rb
@@ -2,12 +2,10 @@ class FormWrapperComponent < ViewComponent::Base
   renders_one :form_content
 
   erb_template <<~ERB
-    <%= form_with model: @model, class: 'space-y-0.5' do |f| %>
-      <div class="bg-white px-4 py-5 shadow sm:p-4">
-        <div class="md:grid md:grid-cols-4 md:gap-6">
-          <%= form_content %>
-        </div>
+    <div class="bg-white px-4 py-5 shadow sm:p-4">
+      <div class="md:grid md:grid-cols-4 md:gap-6">
+        <%= form_content %>
       </div>
-    <% end %>
+    </div>
   ERB
 end


### PR DESCRIPTION
# Fix for #2198 

- Fix after warning from the first change found here from Rails https://rubyonrails.org/2024/2/2/this-week-in-rails
- Cleanup since `form_wrapper_component.rb` was only rendered in the subject forms and did not even use the `form_with `call