### PR TITLE
2257: Filter students by both tag and organization names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased 
+- Added ability to search students by both organization and tag name
 - Updated subject analytics performance charts to render each grade score
 - Added the ability to export basic student data to csv for a group
 - Added `random_alphanumeric_string(length)` DB function to help with MLID generation

--- a/app/models/student_table_row.rb
+++ b/app/models/student_table_row.rb
@@ -39,7 +39,8 @@
 class StudentTableRow < ApplicationRecord
   include PgSearch::Model
   pg_search_scope :search, against: [:first_name, :last_name, :full_mlid], associated_against: {
-    tags: :tag_name
+    tags: :tag_name,
+    organization: :organization_name
   }, using: { tsearch: { prefix: true } }
 
   self.primary_key = :id


### PR DESCRIPTION
# Feature for #2257 

- Added additional scope to include organization names
- Added tests for searching students using tag names, organization names and the combination of both