### PR TITLE
2304: Hide any deleted data when viewing analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Filtered out deleted data when viewing group analytics
+
 ## 0.36.0 - Reworked Student MLIDs and Tags 
 - Added the ability to delete Tags
 - Added ability to search students by both organization and tag name

--- a/app/controllers/analytics/group_controller.rb
+++ b/app/controllers/analytics/group_controller.rb
@@ -10,9 +10,9 @@ module Analytics
     # rubocop:disable Metrics/MethodLength
     def performance_per_group
       groups_lesson_summaries = if selected_param_present_but_not_all?(@selected_chapter_id)
-                                  GroupLessonSummary.where(chapter_id: @selected_chapter_id)
+                                  GroupLessonSummary.joins(:group).where(groups: { deleted_at: nil }).where(chapter_id: @selected_chapter_id)
                                 else
-                                  GroupLessonSummary.joins(:chapter).where(chapters: { organization_id: @selected_organization_id })
+                                  GroupLessonSummary.joins(:group).where(groups: { deleted_at: nil }).joins(:chapter).where(chapters: { organization_id: @selected_organization_id })
                                 end
 
       groups_lesson_summaries

--- a/app/models/group_lesson_summary.rb
+++ b/app/models/group_lesson_summary.rb
@@ -15,6 +15,7 @@
 class GroupLessonSummary < ApplicationRecord
   self.primary_key = :lesson_id
   belongs_to :chapter
+  belongs_to :group
 
   def readonly?
     true

--- a/spec/features/analytics_features_spec.rb
+++ b/spec/features/analytics_features_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'User interacts with Analytics' do
     before :each do
       @chapter = create :chapter
       @group = create :group, chapter: @chapter
+      @deleted_group = create :group, chapter: @chapter, deleted_at: Time.zone.now
       @student = create :graded_student, group: @group, grades: { 'Memorization' => [3, 4, 5, 6, 7], 'Grit' => [2, 3, 2, 4, 5] }
       create :enrollment, group: @group, student: @student, active_since: 1.year.ago
       @organization = @chapter.organization
@@ -15,7 +16,7 @@ RSpec.describe 'User interacts with Analytics' do
     it 'displays general, subject, and group analytics', js: true do
       visit '/'
       click_link 'Analytics'
-      select @organization.organization_name, from: 'organization_select', wait: 10
+      select @organization.organization_name, from: 'organization_select'
       click_link 'Filter'
       expect(page).to have_content('General analytics')
       expect(page).to have_link('Subject analytics')
@@ -38,6 +39,18 @@ RSpec.describe 'User interacts with Analytics' do
       select @organization.organization_name, from: 'organization_select'
       click_link 'Filter'
       expect(page).to have_content(@group.group_chapter_name)
+    end
+
+    it 'does not display deleted group analytics', js: true do
+      visit '/'
+      click_link 'Analytics'
+      click_link 'Group analytics'
+
+      select @organization.organization_name, from: 'organization_select'
+      click_link 'Filter'
+
+      expect(page).to have_content(@group.group_chapter_name)
+      expect(page).not_to have_content(@deleted_group.group_chapter_name)
     end
   end
 end

--- a/spec/models/group_lesson_summary_spec.rb
+++ b/spec/models/group_lesson_summary_spec.rb
@@ -15,6 +15,11 @@
 require 'rails_helper'
 
 RSpec.describe GroupLessonSummary, type: :model do
+  describe 'relationships' do
+    it { should belong_to :chapter }
+    it { should belong_to :group }
+  end
+
   describe '#readonly?' do
     before :each do
       @group = create :group


### PR DESCRIPTION
# Feature for #2304 

- Updated GroupLessonSummary model
- Filtered out group lesson summaries in group analytics for deleted groups
- Added a couple of tests