### PR TITLE
Update Docker image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,7 @@ name: Build and Publish Docker Image
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build_image:
@@ -24,7 +25,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'release' }}
           build-args: |
             APP_ENV=prod
           tags: |


### PR DESCRIPTION
Builds on master started failing with the following error message `Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version`. This is due to the github action being unchanged for some time.

- Updated `docker-image.yml`

 