### PR TITLE
2549: Handle Lesson duplicate uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Handled duplicate lesson uploads by returning a `409` Conflict
 - Added `deleted_lesson.rb` model and ability to hard delete lessons
 - Cleanup and improved performance when viewing lessons
 

--- a/app/controllers/api/lessons_controller.rb
+++ b/app/controllers/api/lessons_controller.rb
@@ -33,16 +33,20 @@ module Api
     end
 
     def save_lesson(lesson)
-      respond_with_existing_lesson unless lesson.save
+      respond_with_existing_or_conflicting_lesson(lesson) unless lesson.save
     rescue ActiveRecord::RecordNotUnique
-      respond_with_existing_lesson
+      respond_with_existing_or_conflicting_lesson lesson
     end
 
-    def respond_with_existing_lesson
-      lesson = Lesson.find_by lesson_params
-      return unless lesson
+    def respond_with_existing_or_conflicting_lesson(lesson)
+      existing_lesson = Lesson.find_by id: lesson.id
+      return respond_with(existing_lesson, status: :ok, meta: { timestamp: Time.zone.now }) if existing_lesson
 
-      respond_with(lesson, status: :ok, meta: { timestamp: Time.zone.now })
+      duplicate_params = lesson_params.slice(:group_id, :date, :subject_id)
+      return unless duplicate_params.values.all?(&:present?)
+
+      conflicting_lesson = Lesson.find_by duplicate_params
+      respond_with(conflicting_lesson, status: :conflict, meta: { timestamp: Time.zone.now }) if conflicting_lesson
     end
   end
 end

--- a/spec/controllers/api/lessons_controller_spec.rb
+++ b/spec/controllers/api/lessons_controller_spec.rb
@@ -44,13 +44,38 @@ RSpec.describe Api::LessonsController, type: :controller do
       end
     end
 
-    context 'lesson already exists' do
+    context 'lesson already exists with the same ID' do
       before :each do
-        create :lesson, group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs
-        post :create, format: :json, params: { group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs }
+        @existing_lesson = create :lesson, group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs
+        post :create, format: :json, params: { id: @existing_lesson.id, group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs }
       end
 
       it { should respond_with 200 }
+
+      it 'responds with the existing lesson' do
+        expect(lesson['id']).to eq @existing_lesson.id
+      end
+    end
+
+    context 'lesson already exists with a different ID' do
+      before :each do
+        @existing_lesson = create :lesson, group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs
+        post :create, format: :json, params: { id: 'bbbe6756-1737-4660-b7e5-e95ae0600124', group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs }
+      end
+
+      it { should respond_with :conflict }
+
+      it 'responds with the conflicting lesson' do
+        expect(lesson['id']).to eq @existing_lesson.id
+      end
+    end
+
+    context 'lesson cannot be created for a non-duplicate reason' do
+      before :each do
+        post :create, format: :json, params: { id: 'bbbe6756-1737-4660-b7e5-e95ae0600124', group_id: @group.id, date: Time.zone.today.to_fs }
+      end
+
+      it { should respond_with :unprocessable_content }
     end
   end
 end

--- a/spec/requests/lesson_requests_spec.rb
+++ b/spec/requests/lesson_requests_spec.rb
@@ -180,10 +180,10 @@ RSpec.describe 'Lesson API', type: :request do
         end
       end
 
-      context 'lesson already exists' do
+      context 'lesson already exists with the same ID' do
         before :each do
           @existing_lesson = create :lesson, id: '5e9d2b0e-1dc6-4c04-b70c-9d67c20b083e', group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs
-          post_v2_with_token lessons_path, as: :json, params: { group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs }
+          post_v2_with_token lessons_path, as: :json, params: { id: @existing_lesson.id, group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs }
         end
 
         it 'responds with existing lesson' do
@@ -191,6 +191,38 @@ RSpec.describe 'Lesson API', type: :request do
           expect(lesson['subject_id']).to eq @subject.id
           expect(lesson['group_id']).to eq @group.id
           expect(Time.zone.parse(lesson['date'])).to eq Time.zone.today
+        end
+
+        it 'responds with ok' do
+          expect(response).to have_http_status :ok
+        end
+      end
+
+      context 'lesson already exists with a different ID' do
+        before :each do
+          @existing_lesson = create :lesson, id: '5e9d2b0e-1dc6-4c04-b70c-9d67c20b083e', group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs
+          post_v2_with_token lessons_path, as: :json, params: { id: 'bbbe6756-1737-4660-b7e5-e95ae0600124', group_id: @group.id, subject_id: @subject.id, date: Time.zone.today.to_fs }
+        end
+
+        it 'responds with the duplicate lesson' do
+          expect(lesson['id']).to eq @existing_lesson.id
+          expect(lesson['subject_id']).to eq @subject.id
+          expect(lesson['group_id']).to eq @group.id
+          expect(Time.zone.parse(lesson['date'])).to eq Time.zone.today
+        end
+
+        it 'responds with conflict' do
+          expect(response).to have_http_status :conflict
+        end
+      end
+
+      context 'lesson cannot be created for a non-duplicate reason' do
+        before :each do
+          post_v2_with_token lessons_path, as: :json, params: { id: 'bbbe6756-1737-4660-b7e5-e95ae0600124', group_id: @group.id, date: Time.zone.today.to_fs }
+        end
+
+        it 'responds with unprocessable content' do
+          expect(response).to have_http_status :unprocessable_content
         end
       end
     end


### PR DESCRIPTION
# Feature for #2549 

- Modified `lessons.controller.rb` to return duplicate lesson as a CONFLICT if it exists for a certain group/subject/date combination
- Added specs