### PR TITLE
Enrollment & Analytics Scoping Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fixed scoping issue in analytics
 - Handled duplicate lesson uploads by returning a `409` Conflict
 - Added `deleted_lesson.rb` model and ability to hard delete lessons
 - Cleanup and improved performance when viewing lessons

--- a/app/controllers/analytics/analytics_controller.rb
+++ b/app/controllers/analytics/analytics_controller.rb
@@ -10,7 +10,7 @@ module Analytics
       @available_subjects = policy_scope Subject.where(deleted_at: nil)
       @available_students = []
 
-      @selected_organization_id = params[:organization_id] || @available_organizations.first.id
+      @selected_organization_id = params[:organization_id].presence || @available_organizations.first&.id
       @selected_chapter_id = params[:chapter_id]
       @subject = params[:subject_id] || @available_subjects.first&.id
       @selected_group_ids = params[:group_ids]
@@ -21,7 +21,9 @@ module Analytics
     end
 
     def default_from_date
-      organization = Organization.find(@selected_organization_id)
+      organization = policy_scope(Organization).find_by(id: @selected_organization_id)
+      return Date.new(Date.current.year, 1, 1) unless organization
+
       last_lesson_date = Lesson.joins(:grades)
                                .where(grades: { student_id: organization.students.select(:id) })
                                .order(date: :desc)
@@ -31,10 +33,12 @@ module Analytics
     end
 
     def find_resource_by_id_param(id, resource_class)
-      return resource_class.where(id:) unless all_selected?(id)
-      return policy_scope(yield resource_class) if block_given?
+      scoped_resources = policy_scope(resource_class)
+      scoped_resources = yield scoped_resources if block_given?
 
-      policy_scope resource_class
+      return scoped_resources if all_selected?(id)
+
+      scoped_resources.where(id:)
     end
 
     def all_selected?(id_selected)

--- a/app/controllers/analytics/general_controller.rb
+++ b/app/controllers/analytics/general_controller.rb
@@ -123,11 +123,11 @@ module Analytics
 
     def groups_for_average_performance
       if @selected_group_ids.present?
-        Group.where(id: @selected_group_ids, deleted_at: nil)
+        policy_scope(Group).where(id: @selected_group_ids, deleted_at: nil)
       elsif selected_param_present_but_not_all?(@selected_chapter_id)
-        Group.where(chapter_id: @selected_chapter_id, deleted_at: nil)
+        policy_scope(Group).where(chapter_id: @selected_chapter_id, deleted_at: nil)
       else
-        Group.joins(:chapter).where(chapters: { organization_id: @selected_organization_id }).where(deleted_at: nil)
+        policy_scope(Group).joins(:chapter).where(chapters: { organization_id: @selected_organization_id }).where(deleted_at: nil)
       end
     end
   end

--- a/app/controllers/analytics/group_controller.rb
+++ b/app/controllers/analytics/group_controller.rb
@@ -8,11 +8,11 @@ module Analytics
     # rubocop:disable Metrics/MethodLength
     def performance_per_group_by_lesson
       selected_groups = if @selected_group_ids.present?
-                          Group.where(id: @selected_group_ids, deleted_at: nil)
+                          policy_scope(Group).where(id: @selected_group_ids, deleted_at: nil)
                         elsif selected_param_present_but_not_all?(@selected_chapter_id)
-                          Group.where(chapter_id: @selected_chapter_id, deleted_at: nil)
+                          policy_scope(Group).where(chapter_id: @selected_chapter_id, deleted_at: nil)
                         else
-                          Group.joins(:chapter).where(chapters: { organization_id: @selected_organization_id }).where(deleted_at: nil)
+                          policy_scope(Group).joins(:chapter).where(chapters: { organization_id: @selected_organization_id }).where(deleted_at: nil)
                         end
       groups = Array(selected_groups)
       conn = ActiveRecord::Base.connection.raw_connection

--- a/app/controllers/analytics/subject_controller.rb
+++ b/app/controllers/analytics/subject_controller.rb
@@ -15,24 +15,24 @@ module Analytics
     private
 
     def performance_per_skill_single_student
-      conn = ActiveRecord::Base.connection.raw_connection
-      students = {}
+      selected_student = find_resource_by_id_param(@selected_student_id, Student).first
+      return [] unless selected_student
 
-      sql = Sql.performance_per_skill_in_lessons_per_student_query_with_dates([@selected_student_id.to_i])
+      conn = ActiveRecord::Base.connection.raw_connection
+
+      sql = Sql.performance_per_skill_in_lessons_per_student_query_with_dates([selected_student.id])
       query_result = conn.exec_params(sql, [@from, @to]).values
       result = query_result.reduce({}) do |acc, e|
-        student_id = e[-1]
-        student_name = students[student_id] ||= Student.find(student_id).proper_name
         skill_name = e[-2]
         acc.tap do |a|
           if a.key?(skill_name)
-            if a[skill_name].key?(student_name)
-              a[skill_name][student_name].push(x: e[0] + 1, y: e[1], lesson_url: lesson_path(e[2]), date: e[3])
+            if a[skill_name].key?(selected_student.proper_name)
+              a[skill_name][selected_student.proper_name].push(x: e[0] + 1, y: e[1], lesson_url: lesson_path(e[2]), date: e[3])
             else
-              a[skill_name][student_name] = [{ x: e[0] + 1, y: e[1], lesson_url: lesson_path(e[2]), date: e[3] }]
+              a[skill_name][selected_student.proper_name] = [{ x: e[0] + 1, y: e[1], lesson_url: lesson_path(e[2]), date: e[3] }]
             end
           else
-            a[skill_name] = { student_name => [{ x: e[0] + 1, y: e[1], lesson_url: lesson_path(e[2]), date: e[3] }] }
+            a[skill_name] = { selected_student.proper_name => [{ x: e[0] + 1, y: e[1], lesson_url: lesson_path(e[2]), date: e[3] }] }
           end
         end
       end

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -85,12 +85,13 @@ class Enrollment < ApplicationRecord
     original_enrollment = Enrollment.find_by(id: id)
     if original_enrollment.present?
       lessons = Lesson.where(group_id: original_enrollment.group_id)
-      all_grades = Grade.where(student_id: original_enrollment.student_id, lesson_id: lessons, deleted_at: nil)
+      grades = Grade.where(student_id: original_enrollment.student_id, lesson_id: lessons, deleted_at: nil)
 
       if active_since != original_enrollment.active_since || inactive_since != original_enrollment.inactive_since
-        current_grades = Grade.where(student_id: student_id, lesson_id: lessons, deleted_at: nil, created_at: active_since..inactive_since)
+        new_lesson_list = Lesson.where(group_id: original_enrollment.group_id, date: active_since..inactive_since)
+        new_grade_list = Grade.where(student_id: student_id, lesson_id: new_lesson_list, deleted_at: nil)
 
-        errors.add(:student, I18n.t(:cannot_change_enrollment_dates_because_grades)) if current_grades.count != all_grades.count
+        errors.add(:student, I18n.t(:cannot_change_enrollment_dates_because_grades)) if new_grade_list.count != grades.count
       end
     end
   end

--- a/spec/controllers/analytics/authorization_spec.rb
+++ b/spec/controllers/analytics/authorization_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.shared_context 'analytics controller setup' do
+  before :each do
+    @allowed_org = create :organization
+    @allowed_user = create :teacher_in, organization: @allowed_org
+    @allowed_chapter = create :chapter, organization: @allowed_org
+    @allowed_group = create :group, chapter: @allowed_chapter
+
+    @foreign_org = create :organization
+    @foreign_chapter = create :chapter, organization: @foreign_org
+    @foreign_group = create :group, chapter: @foreign_chapter
+    @foreign_student = create :enrolled_student, organization: @foreign_org, groups: [@foreign_group]
+    @foreign_subject = create :subject, organization: @foreign_org
+    @foreign_skill = create :skill_with_descriptors, subject: @foreign_subject, organization: @foreign_org, skill_name: 'Memorization'
+    @foreign_lesson = create :lesson, group: @foreign_group, subject: @foreign_subject, date: 1.month.ago.to_date
+    create :grade, student: @foreign_student, lesson: @foreign_lesson, grade_descriptor: @foreign_skill.grade_descriptors.find_by(mark: 5)
+
+    sign_in @allowed_user
+  end
+end
+
+RSpec.describe Analytics::GeneralController, type: :controller do
+  include_context 'analytics controller setup'
+
+  it 'does not use explicitly requested records outside scope' do
+    get :index, params: {
+      organization_id: @foreign_org.id,
+      chapter_id: @foreign_chapter.id,
+      group_ids: [@foreign_group.id],
+      student_id: @foreign_student.id,
+      from_date: 2.years.ago.to_date.to_s,
+      to_date: Date.current.to_s
+    }
+
+    expect(assigns(:selected_students)).to be_empty
+    expect(JSON.parse(assigns(:average_group_performance))).to be_empty
+    expect(assigns(:number_of_data_points)).to eq 0
+  end
+end
+
+RSpec.describe Analytics::GroupController, type: :controller do
+  include_context 'analytics controller setup'
+
+  it 'does not build group series for explicitly requested groups outside scope' do
+    get :index, params: {
+      organization_id: @allowed_org.id,
+      group_ids: [@foreign_group.id],
+      from_date: 2.years.ago.to_date.to_s,
+      to_date: Date.current.to_s
+    }
+
+    expect(assigns(:group_series)).to be_empty
+  end
+end
+
+RSpec.describe Analytics::SubjectController, type: :controller do
+  include_context 'analytics controller setup'
+
+  it 'does not build student skill series for an explicitly requested student outside scope' do
+    get :index, params: {
+      organization_id: @allowed_org.id,
+      student_id: @foreign_student.id,
+      from_date: 2.years.ago.to_date.to_s,
+      to_date: Date.current.to_s
+    }
+
+    expect(assigns(:subject_series)).to be_empty
+  end
+end

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -188,6 +188,22 @@ RSpec.describe Enrollment, type: :model do
       expect(enrollment.errors[:student]).to eq [I18n.t(:cannot_change_enrollment_dates_because_grades)]
     end
 
+    it 'validates grade coverage using lesson dates instead of grade creation dates' do
+      organization = create :organization
+      chapter = create :chapter, organization: organization
+      group = create :group, chapter: chapter
+      student = create :student, organization: organization
+      lesson = create :lesson, group: group, date: 10.days.ago
+      create :grade, student: student, lesson: lesson, created_at: Time.zone.now
+
+      enrollment = create :enrollment, student: student, group: group, active_since: 10.days.ago
+      enrollment.update(active_since: 1.day.ago)
+
+      expect(enrollment.valid?).to be false
+      expect(enrollment.errors.size).to eq(1)
+      expect(enrollment.errors[:student]).to eq [I18n.t(:cannot_change_enrollment_dates_because_grades)]
+    end
+
     it 'validates no grades are lost when an enrollment has been deleted' do
       organization = create :organization
       chapter = create :chapter, organization: organization


### PR DESCRIPTION
- Modified `analytics_controller.rb` to always use policy scoping for resources selected by id
- Modified the rest of the analytics controllers to use policy scoping for fetching records
- Modified `enrollment.rb` to use lesson dates when checking for lost grades during update