### PR TITLE
Fix(2639): Trigger print preview automatically on student report load

### DIFF
--- a/app/assets/javascripts/new_charts.js
+++ b/app/assets/javascripts/new_charts.js
@@ -1329,7 +1329,7 @@ function displayMarkAveragesChart(containerId, data, opts = {}) {
 function displayStudentReportPerformanceByGroupChart(containerId, groupedData, opts = {}) {
     if (!chartJsPresent()) return
 
-    const canvas = ensureCanvasIsPresent(containerId, { heightPx: opts.heightPx || 500 })
+    const canvas = ensureCanvasIsPresent(containerId, { heightPx: opts.heightPx || 1100 })
     if (!canvas) return
 
     destroyIfExists(canvas)
@@ -1346,8 +1346,8 @@ function displayStudentReportPerformanceByGroupChart(containerId, groupedData, o
                 legend: {
                     display: true,
                     labels: {
-                        padding: 10,
-                        font: { size: 12 }
+                        padding: 18,
+                        font: { size: 18 }
                     }
                 },
                 tooltip: {
@@ -1387,20 +1387,24 @@ function displayStudentReportPerformanceByGroupChart(containerId, groupedData, o
                     type: "linear",
                     title: {
                         display: true,
-                        text: opts.xTitle || "Lesson date"
+                        text: opts.xTitle || "Lesson date",
+                        font: { size: 20 }
                     },
                     ticks: {
+                        font: { size: 16 },
                         callback: (value) => toUSdateFormat(Number(value))
                     }
                 },
                 y: {
                     title: {
                         display: true,
-                        text: opts.yTitle || "Performance"
+                        text: opts.yTitle || "Performance",
+                        font: { size: 20 }
                     },
                     min: 1,
                     max: 7,
                     ticks: {
+                        font: { size: 16 },
                         precision: 0
                     }
                 }
@@ -1427,7 +1431,7 @@ function displayStudentReportPerformanceByGroupChart(containerId, groupedData, o
 function displayStudentSkillRegressionChart(containerId, skillSeriesJson, opts = {}) {
     if (!chartJsPresent()) return
 
-    const canvas = ensureCanvasIsPresent(containerId, { heightPx: opts.heightPx || 500 })
+    const canvas = ensureCanvasIsPresent(containerId, { heightPx: opts.heightPx || 1100 })
     if (!canvas) return
     destroyIfExists(canvas)
 
@@ -1443,15 +1447,15 @@ function displayStudentSkillRegressionChart(containerId, skillSeriesJson, opts =
                 title: {
                     display: true,
                     text: opts.title || "Student progress by skill",
-                    font: { size: 20 }
+                    font: { size: 28 }
                 },
                 legend: {
                     display: true,
                     labels: {
-                        padding: 10,
-                        font: { size: 11 },
-                        boxHeight: 10,
-                        boxWidth: 10
+                        padding: 18,
+                        font: { size: 16 },
+                        boxHeight: 14,
+                        boxWidth: 14
                     }
                 },
                 tooltip: {
@@ -1476,14 +1480,14 @@ function displayStudentSkillRegressionChart(containerId, skillSeriesJson, opts =
                 x: {
                     type: "linear",
                     min: 1,
-                    title: { display: true, text: opts.xTitle || "Nr. of lessons" },
-                    ticks: { precision: 0 }
+                    title: { display: true, text: opts.xTitle || "Nr. of lessons", font: { size: 20 } },
+                    ticks: { font: { size: 16 }, precision: 0 }
                 },
                 y: {
                     min: 1,
                     max: 7,
-                    title: { display: true, text: opts.yTitle || "Performance" },
-                    ticks: { precision: 0 }
+                    title: { display: true, text: opts.yTitle || "Performance", font: { size: 20 } },
+                    ticks: { font: { size: 16 }, precision: 0 }
                 }
             },
             onHover: function (event) {

--- a/app/views/student_reports/show.html.erb
+++ b/app/views/student_reports/show.html.erb
@@ -194,6 +194,18 @@
 </div>
 
 <script>
+  const handlePrint = () => {
+    Object.values(Chart.instances).forEach(chart => {
+        chart.resize()
+    })
+
+    setTimeout(() => {
+      window.print()
+    }, 1000)
+
+    document.removeEventListener('DOMContentLoaded', handlePrint)
+  }
+
   window.onChartsLoad = function () {
     let groupedSummaries = <%= @grouped_student_summaries.to_json.html_safe %>;
     let performancePerSkill = <%= @performance_per_skill.to_json.html_safe %>;
@@ -205,6 +217,8 @@
       yTitle: "Performance",
       regressionOrder: 3
     })
+
+    document.addEventListener('DOMContentLoaded', handlePrint)
   }
 </script>
 <%= javascript_include_tag "new_charts", onload: 'window.onChartsLoad && window.onChartsLoad()' %>


### PR DESCRIPTION
- Add a DOMContentLoaded handler that resizes charts and callswindow.print() after a delay, which fixes auto print preview not
 opening on initial page load (The same behaviour was implement on group view)
- Increase chart heights and font sizes for legends, axis titles, and ticks so printed charts stay legible at the larger canvas size
<img width="1348" height="930" alt="image" src="https://github.com/user-attachments/assets/8d9bdf39-3c6b-4864-957b-5e48edb0bb5b" />
