### PR TITLE
feat(2648): add bulk tag assignment for students

### DIFF
--- a/app/components/table_components/bulk_tag_student_row.rb
+++ b/app/components/table_components/bulk_tag_student_row.rb
@@ -1,0 +1,22 @@
+class TableComponents::BulkTagStudentRow < TableComponents::BaseRow
+  erb_template <<~ERB
+    <%= hidden_field_tag "students[#{@item_counter}][id]", @item.id %>
+    <div class="<%= 'shaded-row' if shaded? %> table-row-wrapper student-row">
+      <div class="table-cell flex! items-center "><%= @item.first_name %></div>
+      <div class="table-cell flex! items-center "><%= @item.last_name %></div>
+      <div class="text-right table-cell flex! items-center "><% @item.tags.each do |tag| %><span class="mdl-chip"><span class="mdl-chip__text"><%= tag.tag_name %> </span></span><% end %></div>
+      <div class="table-cell flex! items-center ">
+        <%= check_box_tag "students[#{@item_counter}][to_tag]", class: 'h-5 w-5 border-purple-500 focus:ring-green-600 cursor-pointer', checked: false %>
+      </div>
+    </div>
+  ERB
+
+  def self.columns
+    [
+      { column_name: I18n.t(:first_name) },
+      { column_name: I18n.t(:last_name) },
+      { column_name: I18n.t(:tags) },
+      { column_name: I18n.t(:assign) }
+    ]
+  end
+end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -3,12 +3,12 @@ class StudentsController < HtmlController
   include Pagy::Method
   include CollectionHelper
 
-  has_scope :exclude_deleted, only: :index, type: :boolean, default: true
+  has_scope :exclude_deleted, only: [:index, :bulk_tag_assignment], type: :boolean, default: true
   has_scope :table_order, only: [:index], type: :hash, default: { key: :created_at, order: :desc }
   has_scope :student_lesson_order, only: [:show], type: :hash, default: { key: :date, order: :desc } do |_controller, scope, value|
     scope.table_order value
   end
-  has_scope :search, only: :index
+  has_scope :search, only: [:index, :bulk_tag_assignment]
 
   # rubocop:disable Metrics/AbcSize
   def index
@@ -123,7 +123,67 @@ class StudentsController < HtmlController
     redirect_to student_path
   end
 
+  def bulk_tag_assignment
+    authorize Student, :new?
+    @pagy, students = pagy apply_scopes(policy_scope(Student.includes(:tags)))
+    @students = students.to_a
+    @tags = TagPolicy::Scope.new(current_user, Tag).resolve.order(:tag_name)
+  end
+
+  def confirm_bulk_tag_assignment
+    authorize Student, :new?
+    tags = TagPolicy::Scope.new(current_user, Tag).resolve.where(id: Array(params[:tag_ids]).compact_blank).to_a
+
+    if tags.empty?
+      failure title: t(:no_tags_selected), text: t(:select_at_least_one_tag)
+      return redirect_to students_path
+    end
+
+    student_count = perform_bulk_tag_assignment(tags)
+
+    success title: t(:tags_assigned), text: t(:tags_assigned_text, count: student_count, tags: tags.map(&:tag_name).join(', '))
+    redirect_to students_path
+  end
+
   private
+
+  def perform_bulk_tag_assignment(tags)
+    student_ids = policy_scope(Student).where(id: selected_student_ids).pluck(:id)
+    assign_tags_to_students(student_ids, tags.map(&:id))
+    student_ids.size
+  end
+
+  def selected_student_ids
+    params.require(:students).filter_map { |s| s[:id] if s[:to_tag] }
+  end
+
+  # Bulk-inserts the missing (student, tag) pairs in a single query instead of issuing a
+  # find_or_create_by per student per tag, which would otherwise be O(students * tags) queries.
+  def assign_tags_to_students(student_ids, tag_ids)
+    return if student_ids.empty? || tag_ids.empty?
+
+    ActiveRecord::Base.transaction do
+      rows = missing_student_tag_rows(student_ids, tag_ids)
+      next if rows.empty?
+
+      # rubocop:disable Rails/SkipsModelValidations
+      StudentTag.insert_all(rows)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+
+  def missing_student_tag_rows(student_ids, tag_ids)
+    existing_pairs = StudentTag.where(student_id: student_ids, tag_id: tag_ids).pluck(:student_id, :tag_id).to_set
+    now = Time.current
+
+    student_ids.flat_map do |student_id|
+      tag_ids.filter_map do |tag_id|
+        next if existing_pairs.include?([student_id, tag_id])
+
+        { student_id: student_id, tag_id: tag_id, created_at: now, updated_at: now }
+      end
+    end
+  end
 
   def lesson_summary(summary)
     { lesson_date: summary.lesson_date, average_mark: summary.average_mark, lesson_url: lesson_path(summary.lesson_id) }

--- a/app/views/students/bulk_tag_assignment.html.erb
+++ b/app/views/students/bulk_tag_assignment.html.erb
@@ -1,0 +1,45 @@
+<%- content_for :title, t(:assign_tags) %>
+
+<%= render LayoutComponents::HeaderComponent.new(current_user: current_user, tabs: [
+  {title: CommonComponents::TagLabel.new(label: t(:assign_tags), img_src: 'tag.svg'), href: '' }
+], buttons: [
+  CommonComponents::ButtonComponent.new(label: t(:back_to_students), href: students_path)
+]) %>
+
+<div class="bg-white px-4 py-3 border-b border-gray-200">
+  <%= render SearchFormComponent.new(search: { term: params[:search] }, query_parameters: request.query_parameters) %>
+</div>
+
+<% if @students.any? %>
+  <%# The search form above renders its own <form> tag, so it must stay outside this one -- %>
+  <%# nesting <form> elements is invalid HTML and browsers close the outer form early when %>
+  <%# they hit the inner form's closing tag, orphaning the checkboxes/submit button below it. %>
+  <%= form_with url: confirm_bulk_tag_assignment_students_path, html: { method: :post, name: 'students[]' } do %>
+    <div class="bg-white px-4 py-5 shadow-sm sm:p-4">
+      <div class="md:grid md:grid-cols-4 md:gap-6">
+        <div class="md:col-span-1">
+          <label class="block text-sm font-medium text-gray-700"><%= t(:tags) %></label>
+        </div>
+        <div class="md:col-span-3">
+          <div class="grid grid-cols-6 gap-4">
+            <div class="col-span-6 lg:col-span-2">
+              <%= render CommonComponents::MultiselectComponent.new(label: t(:select_tags), target: 'tag_ids[]', options: @tags.map { |tag| { id: tag.id, label: tag.tag_name } }) %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <%= render TableComponents::Table.new(pagy: @pagy, rows: @students, row_component: TableComponents::BulkTagStudentRow) %>
+
+    <div class="p-4">
+      <%= submit_tag t(:confirm), class: 'button normal-button' %>
+      <%= link_to t(:cancel), students_path, class: 'dangerous-button' %>
+    </div>
+  <% end %>
+<% else %>
+  <div class="p-4 bg-white flex items-center gap-2">
+    <span class="text-md font-medium text-gray-700"><%= t(:no_students_found) %></span>
+    <%= link_to t(:cancel), students_path, class: 'dangerous-button' %>
+  </div>
+<% end %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -4,7 +4,8 @@
   {title: CommonComponents::TagLabel.new(label: t(:students).capitalize, img_src: 'student.svg'), href: '' },
   {title: CommonComponents::TagLabel.new(label: t(:student_tags), img_src: 'tag.svg'), href: student_tags_url }
 ], buttons: [
-  (CommonComponents::ButtonComponent.new(label: t(:add_student), href: new_student_path) if policy(Student).new?)
+  (CommonComponents::ButtonComponent.new(label: t(:add_student), href: new_student_path) if policy(Student).new?),
+  (CommonComponents::ButtonComponent.new(label: t(:assign_tags), href: bulk_tag_assignment_students_path(search: params[:search])) if policy(Student).new?)
 ].compact) %>
 
 <%= render TableComponents::Table.new(pagy: @pagy, rows: @student_rows, row_component: TableComponents::StudentRow, options: { empty_message: t(:no_students_found) }) do |t|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -440,6 +440,14 @@ en:
   tag_deleted_text: Tag "%{tag_name}" deleted.
   unable_to_delete_tag: Unable to delete tag
   tag_not_deleted_because_students: Tag not deleted because it has students associated with it. Remove it from the students before deleting.
+  assign_tags: Assign Tags
+  back_to_students: Back to Students
+  select_tags: Select Tags
+  assign: Assign
+  tags_assigned: Tags Assigned
+  tags_assigned_text: Successfully assigned tags "%{tags}" to %{count} students.
+  no_tags_selected: No Tags Selected
+  select_at_least_one_tag: Please select at least one tag to assign.
 
   lesson_date: Lesson Date
   grades_per_skill: Grades Per Skill

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,11 @@ Rails.application.routes.draw do
   resources :students, only: %i[index new create show edit update destroy] do
     member { post :undelete }
 
-    collection { get '/mlid/:organization_id', to: 'students#mlid' }
+    collection do
+      get '/mlid/:organization_id', to: 'students#mlid'
+      get :bulk_tag_assignment
+      post :confirm_bulk_tag_assignment
+    end
 
     resources :student_images, only: %i[create destroy]
   end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -332,5 +332,67 @@ RSpec.describe StudentsController, type: :controller do
         expect(@student.reload.deleted_at).to be_nil
       end
     end
+
+    describe 'bulk tag assignment' do
+      before :each do
+        @tag = create :tag, organization: organization
+        @students = create_list :student, 2, organization: organization
+        @other_student = create :student, organization: organization
+      end
+
+      describe '#bulk_tag_assignment' do
+        before :each do
+          get :bulk_tag_assignment
+        end
+
+        it { should respond_with 200 }
+        it { should render_template :bulk_tag_assignment }
+      end
+
+      describe '#confirm_bulk_tag_assignment' do
+        before :each do
+          first_student = { id: @students[0].id, to_tag: true }
+          second_student = { id: @students[1].id, to_tag: true }
+          third_student = { id: @other_student.id }
+          post :confirm_bulk_tag_assignment, params: { tag_ids: [@tag.id], students: [first_student, second_student, third_student] }
+        end
+
+        it { should redirect_to students_path }
+        it { should set_flash[:success_notice] }
+
+        it 'assigns the tag to checked students only' do
+          expect(@students[0].reload.tags).to include @tag
+          expect(@students[1].reload.tags).to include @tag
+          expect(@other_student.reload.tags).not_to include @tag
+        end
+
+        it 'does not duplicate an existing tag assignment' do
+          post :confirm_bulk_tag_assignment, params: { tag_ids: [@tag.id], students: [{ id: @students[0].id, to_tag: true }] }
+
+          expect(@students[0].reload.student_tags.where(tag: @tag).count).to eq 1
+        end
+
+        it 'assigns multiple tags to multiple students in a single request' do
+          other_tag = create :tag, organization: organization
+          post :confirm_bulk_tag_assignment, params: { tag_ids: [@tag.id, other_tag.id], students: [{ id: @students[0].id, to_tag: true }, { id: @students[1].id, to_tag: true }] }
+
+          expect(@students[0].reload.tags).to include(@tag, other_tag)
+          expect(@students[1].reload.tags).to include(@tag, other_tag)
+        end
+      end
+
+      describe '#confirm_bulk_tag_assignment when no tags are selected' do
+        before :each do
+          post :confirm_bulk_tag_assignment, params: { tag_ids: [], students: [{ id: @other_student.id, to_tag: true }] }
+        end
+
+        it { should redirect_to students_path }
+        it { should set_flash[:failure_notice] }
+
+        it 'does not assign the tag' do
+          expect(@other_student.reload.tags).not_to include @tag
+        end
+      end
+    end
   end
 end

--- a/spec/features/bulk_tag_assignment_features_spec.rb
+++ b/spec/features/bulk_tag_assignment_features_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'User interacts with bulk tag assignment' do
+  include_context 'login_with_global_admin'
+
+  before :each do
+    @org = create :organization
+    @tag_one = create :tag, tag_name: 'Bulk Tag One', organization: @org
+    @tag_two = create :tag, tag_name: 'Bulk Tag Two', organization: @org
+    @first_student = create :student, organization: @org, first_name: 'Bulka', last_name: 'Studentova'
+    @second_student = create :student, organization: @org, first_name: 'Bulkette', last_name: 'Studentovna'
+  end
+
+  it 'assigns tags to the selected students from a dedicated page', js: true do
+    visit '/students'
+    click_link 'Assign Tags'
+
+    expect(page).to have_current_path(bulk_tag_assignment_students_path)
+
+    toggle_button = find('button[data-action="click->multiselect#toggleMenu"]')
+    toggle_button.click
+    find('[data-multiselect-target="option"]', text: @tag_one.tag_name).click
+    toggle_button.click
+
+    within(:xpath, ".//div[contains(@class, 'student-row') and contains(., 'Bulka')]") do
+      find('input[type="checkbox"]').check
+    end
+
+    click_button 'Confirm'
+
+    expect(page).to have_content 'Tags Assigned'
+    expect(page).to have_content "Successfully assigned tags \"#{@tag_one.tag_name}\" to 1 students."
+
+    expect(@first_student.reload.tags).to include @tag_one
+    expect(@second_student.reload.tags).not_to include @tag_one
+  end
+
+  it 'shows a failure message when confirming without selecting a tag', js: true do
+    visit '/students'
+    click_link 'Assign Tags'
+
+    within(:xpath, ".//div[contains(@class, 'student-row') and contains(., 'Bulka')]") do
+      find('input[type="checkbox"]').check
+    end
+
+    click_button 'Confirm'
+
+    expect(page).to have_content 'No Tags Selected'
+    expect(@first_student.reload.tags).not_to include @tag_one
+  end
+
+  it 'shows a message when there are no students to tag' do
+    Student.find_each { |student| student.update!(deleted_at: Time.zone.now) }
+
+    visit '/students'
+    click_link 'Assign Tags'
+
+    expect(page).to have_content 'No Students found'
+  end
+end


### PR DESCRIPTION
Adds a dedicated page for assigning tags to multiple students at once, with a single bulk insert instead of per-pair writes.